### PR TITLE
fp8 lane: drop enforce-eager by default, set max-num-batched-tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,43 @@ The density win above is **not free** — we ran both lanes back-to-back on the 
 
 **What this means:** NVFP4 KV's ~33 % slower decode is the b12x `B12X_MLA_SPARSE` sparse-attention path (+ the per-token NVFP4 dequant) doing more compute per step than fp8's marlin path — and `--enforce-eager`, which the b12x kernels require, caps single-stream on both lanes. So the trade is clean: **NVFP4 = KV *capacity* (bigger context pool at equal VRAM), fp8 = *speed* (faster tokens for the same agent work).** For our production endpoint we run **fp8 as the daily driver** (faster, uncensored, vision, simplest to operate) and keep **NVFP4 as the flex** for the rare job that needs the giant pool over throughput.
 
+## Two flags on the fp8 lane (contributed, measured on a separate 4-Spark fleet)
+
+Both apply to `launch-glm53-vllm-tp4.sh`. Numbers below come from 4x GB10 at TP4,
+`--max-model-len 1048576`, fp8 KV, so the shape should transfer even though the absolute
+values will not.
+
+**`--enforce-eager` is not needed on the fp8 lane at TP4.** It is carried because the b12x
+kernels on the NVFP4 lane require it, and the README already notes it caps single stream.
+At TP4 each rank holds ~50 GiB of weights rather than the ~97 GiB that makes capture OOM at
+TP2, so CUDA-graph capture fits — 44-91 s, 0.3-1.8 GiB depending on `--max-num-seqs`.
+
+| | `--enforce-eager` | `cudagraph_mode: FULL_DECODE_ONLY` |
+|---|---|---|
+| per-step latency | 203.2 ms | **82.6 ms** |
+| step rate | 4.92 steps/s | **12.10 steps/s** |
+| MTP acceptance | 73.8 % | **81.9 %** |
+| end-to-end | 19.4 tok/s | **51.7 tok/s** |
+
+The launcher now takes `EAGER=1` to restore the old behaviour for the b12x lane; default
+is the graph path.
+
+**`--max-num-batched-tokens` was unset.** vLLM then derives 2048 from the speculative
+settings and warns at startup that this is suboptimal — the line reads like boilerplate and
+is easy to scroll past. On a 32K prompt, single stream:
+
+| value | TTFT | prefill tok/s | head-rank memory |
+|---|---|---|---|
+| 2048 (derived) | 20,685 ms | 1,584 | 110 GiB |
+| 4096 | 16,435 ms | 1,994 | 109 GiB |
+| **8192** | **14,595 ms** | **2,245** | 111 GiB |
+
+−29 % TTFT and +42 % prefill throughput for about +1 GiB. The slope flattens past 8192 while
+head-rank headroom drops, which is where it was left.
+
+Measurements and harnesses:
+[tonyliu312/GLM-5.3-Flash-DFlash2-TP4-1M-Context](https://github.com/tonyliu312/GLM-5.3-Flash-DFlash2-TP4-1M-Context)
+
 ## Numbers
 
 | Metric | TP4 flagship |

--- a/launch-glm53-vllm-tp4.sh
+++ b/launch-glm53-vllm-tp4.sh
@@ -7,6 +7,12 @@ set -euo pipefail
 # Run cache_flusher.sh alongside on every node (GB10 NVRM allocator, see repo docs).
 NODE_RANK="${1:?usage: launch-glm53-vllm-tp4.sh <0|1|2|3>}"
 
+# EAGER=1 restores --enforce-eager, which the b12x / NVFP4-KV lane requires.
+# The fp8 lane on TP4 does not need it: each rank holds ~50 GiB of weights, so
+# CUDA-graph capture fits (44-91 s, 0.3-1.8 GiB). Leaving it on caps single
+# stream -- see README for the measured difference.
+EAGER="${EAGER:-}"
+
 IMAGE="radixark/vllm-glm53-flash:sm121-v8"
 NAME="vllm_glm53"
 MODEL_HOST_PATH="/var/tmp/glm-5.3-flash-nvfp4"
@@ -60,7 +66,8 @@ docker run --gpus all -d \
     --gpu-memory-utilization 0.85 \
     --max-model-len 1048576 \
     --max-num-seqs 6 --block-size 2304 --moe-backend marlin --speculative-config '{"method":"mtp","num_speculative_tokens":4}' --kv-cache-dtype fp8_e4m3 --kv-cache-memory 25769803776 \
-    --enforce-eager \
+    --max-num-batched-tokens 8192 \
+    ${EAGER:+--enforce-eager} ${EAGER:---compilation-config '{"cudagraph_mode":"FULL_DECODE_ONLY"}'} \
     --tool-call-parser glm47 --enable-auto-tool-choice \
     --reasoning-parser glm45 --chat-template /models/glm-5.3-flash-nvfp4/chat_template_mm.jinja --default-chat-template-kwargs '{"enable_thinking": false}' \
     --distributed-executor-backend mp \


### PR DESCRIPTION
Following up on your reply — two flags on `launch-glm53-vllm-tp4.sh`. Both measured on a separate 4-Spark fleet at TP4, 1M context, fp8 KV, so the absolute numbers will differ on yours but the shape should hold.

### `--enforce-eager` on the fp8 lane

Your README already says it caps single stream and that the b12x kernels are what require it. On the fp8 lane at TP4 it isn't needed — each rank holds ~50 GiB of weights rather than the ~97 GiB that makes capture OOM at TP2, so CUDA-graph capture fits in 44–91 s and 0.3–1.8 GiB.

| | `--enforce-eager` | `cudagraph_mode: FULL_DECODE_ONLY` |
|---|---|---|
| per-step latency | 203.2 ms | **82.6 ms** |
| step rate | 4.92 steps/s | **12.10 steps/s** |
| MTP acceptance | 73.8 % | **81.9 %** |
| end-to-end | 19.4 tok/s | **51.7 tok/s** |

I didn't remove it — `EAGER=1` restores the old behaviour so the b12x lane still works off the same launcher. Default is the graph path.

### `--max-num-batched-tokens`

Unset, so vLLM derives 2048 from the speculative settings and warns it's suboptimal. That line reads like boilerplate; I scrolled past it for two days before it registered.

32K prompt, single stream:

| value | TTFT | prefill tok/s | head-rank memory |
|---|---|---|---|
| 2048 (derived) | 20,685 ms | 1,584 | 110 GiB |
| 4096 | 16,435 ms | 1,994 | 109 GiB |
| **8192** | **14,595 ms** | **2,245** | 111 GiB |

−29 % TTFT and +42 % prefill for about +1 GiB. Stops paying past 8192 while head-rank headroom drops, so that's where I left it.

### Caveats

Measured with MTP-4, not DFlash2, on a fleet with different memory headroom than yours. If your head rank sits closer to its ceiling than mine, 4096 is the safer step.

Harnesses and the full measurement set: https://github.com/tonyliu312/GLM-5.3-Flash-DFlash2-TP4-1M-Context

Happy to drop either half if only one is useful.