### PR TITLE
fix: exact torch.topk routing for DFlash2 top-k oversubscription (GB10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,9 @@ The density win above is **not free** — we ran both lanes back-to-back on the 
 
 - [`overlay-dflash2/`](overlay-dflash2/) — the DFlash2 vLLM overlay: patches plus a CPU
   simulator that validates the KV geometry before you boot a node.
+- [`docker/topkfix/`](docker/topkfix/) — exact-`torch.topk` top-k fix for Disease 1
+  (cleaner than the SM-count gate). See
+  [`docs/TOPK-OVERSUSCRIPTION-FIX.md`](docs/TOPK-OVERSUSCRIPTION-FIX.md).
 - [`docs/SM121-CRASH-FORENSICS-2026-08-27.md`](docs/SM121-CRASH-FORENSICS-2026-08-27.md) — the
   two diseases behind "random" deaths, and the gate suite.
 - [`docs/DEPLOY-REPORT.md`](docs/DEPLOY-REPORT.md) — every failure and receipt from deploy day.

--- a/docker/topkfix/Dockerfile
+++ b/docker/topkfix/Dockerfile
@@ -1,0 +1,5 @@
+FROM ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v11-dflash2
+ARG VLLM=/usr/local/lib/python3.12/dist-packages/vllm
+COPY patch_kpool_topk.py /tmp/patch_kpool_topk.py
+RUN python3 /tmp/patch_kpool_topk.py && \
+    python3 -c "import ast,pathlib; p=pathlib.Path('$VLLM/model_executor/layers/sparse_attn_indexer_kpool.py'); ast.parse(p.read_text()); t=p.read_text(); assert '_USE_TORCH_TOPK' in t and t.count('_torch_decode_topk')>=2 and t.count('_torch_prefill_topk')>=2, 'topkfix markers missing'; print('topkfix apply + AST check OK')"

--- a/docker/topkfix/patch_kpool_topk.py
+++ b/docker/topkfix/patch_kpool_topk.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""Custom sm_12x torch.topk routing for GLM-5.3-Flash kpool sparse-attention indexer.
+
+Fixes the GB10 crash:
+  launch_persistent_topk ... persistent_topk would oversubscribe and the
+  FilteredTopK fallback requires >=128KB smem per block (have 101376).
+  total_ctas=60 > num_sms*occupancy=48 (TopK=512)
+
+Root cause: the fused indexer top-k kernels (persistent_topk decode,
+top_k_per_row_prefill prefill) launch CTAs proportional to logits width
+(== max_model_len), so large context oversubscribes GB10's 48 SMs and trips a
+FilteredTopK fallback needing >=128KB smem/block (GB10 has ~99KB/101376B).
+Exact torch.topk is context-length independent.
+
+GLM-5.3 kpool: logits/seq_lens are POOL-granular (compress_ratio == index_kpool);
+selection is on pools (select_k = topk_tokens // index_kpool), matching the
+kernel contract. The -1 padding sentinel is preserved for the expand kernels.
+"""
+import sys
+from pathlib import Path
+
+VLLM = Path("/usr/local/lib/python3.12/dist-packages/vllm")
+TARGET = VLLM / "model_executor/layers/sparse_attn_indexer_kpool.py"
+
+ANCHOR_HELPERS = "RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024\n"
+
+HELPERS = '''RADIX_TOPK_WORKSPACE_SIZE = 1024 * 1024
+
+# GB10 / consumer Blackwell (sm_12x): the fused indexer top-k kernels
+# (persistent_topk decode / top_k_per_row_prefill prefill) launch CTAs sized
+# to logits width (== max_model_len), so large context oversubscribes the 48
+# SMs and crashes on the FilteredTopK fallback (needs >=128KB smem/block;
+# GB10 exposes ~99KB/101376B). torch.topk is exact and context-length
+# independent. kpool logits/seq_lens are POOL-granular; selection is on pools
+# (select_k = topk_tokens // index_kpool), matching the fused-kernel contract.
+_USE_TORCH_TOPK = current_platform.is_device_capability_family(120)
+
+
+def _torch_decode_topk(logits, seq_lens, topk_indices, topk_tokens):
+    R, N = logits.shape
+    dev = logits.device
+    k = min(int(topk_tokens), N)
+    cols = torch.arange(N, device=dev)
+    # seq_lens is 2D (B, next_n) for native spec decode; logits rows are the
+    # flattened (B*next_n) tokens in the same order.
+    sl = seq_lens.reshape(-1)[:R].to(torch.long)
+    valid = cols[None, :] < sl[:, None]
+    masked = torch.where(valid, logits, torch.full_like(logits, float("-inf")))
+    _, idx = torch.topk(masked, k, dim=-1)
+    sel_valid = torch.gather(valid, 1, idx)
+    idx = torch.where(sel_valid, idx.to(torch.int32),
+                      torch.full_like(idx, -1, dtype=torch.int32))
+    topk_indices[:R, :k] = idx
+    if k < topk_tokens:
+        topk_indices[:R, k:] = -1
+
+
+def _torch_prefill_topk(logits, cu_seqlen_ks, cu_seqlen_ke, topk_indices, topk_tokens):
+    R, N = logits.shape
+    dev = logits.device
+    k = min(int(topk_tokens), N)
+    cols = torch.arange(N, device=dev)
+    ks = cu_seqlen_ks[:R].to(torch.long)[:, None]
+    ke = cu_seqlen_ke[:R].to(torch.long)[:, None]
+    valid = (cols[None, :] >= ks) & (cols[None, :] < ke)
+    masked = torch.where(valid, logits, torch.full_like(logits, float("-inf")))
+    _, idx = torch.topk(masked, k, dim=-1)
+    sel_valid = torch.gather(valid, 1, idx)
+    idx = torch.where(sel_valid, idx.to(torch.int32),
+                      torch.full_like(idx, -1, dtype=torch.int32))
+    topk_indices[:R, :k] = idx
+    if k < topk_tokens:
+        topk_indices[:R, k:] = -1
+'''
+
+# Decode path: insert torch.topk branch before the fused persistent_topk call.
+DECODE_OLD = """        if current_platform.is_cuda() and select_k in (512, 1024, 2048):
+            workspace_manager = current_workspace_manager()
+            (topk_workspace,) = workspace_manager.get_simultaneous(
+                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+            )
+            torch.ops._C.persistent_topk("""
+
+DECODE_NEW = """        if _USE_TORCH_TOPK:
+            _torch_decode_topk(logits, seq_lens, topk_dst, select_k)
+        elif current_platform.is_cuda() and select_k in (512, 1024, 2048):
+            workspace_manager = current_workspace_manager()
+            (topk_workspace,) = workspace_manager.get_simultaneous(
+                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+            )
+            torch.ops._C.persistent_topk("""
+
+# Prefill path: insert torch.topk branch before the is_xpu()/top_k_per_row_prefill.
+PREFILL_OLD = """            if current_platform.is_xpu():
+                xpu_ops.top_k_per_row_prefill(  # type: ignore[attr-defined]
+                    logits,
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                    topk_dst,
+                    num_rows,
+                    logits.stride(0),
+                    logits.stride(1),
+                    select_k,
+                )
+            else:
+                torch.ops._C.top_k_per_row_prefill("""
+
+PREFILL_NEW = """            if _USE_TORCH_TOPK:
+                _torch_prefill_topk(
+                    logits,
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                    topk_dst,
+                    select_k,
+                )
+            elif current_platform.is_xpu():
+                xpu_ops.top_k_per_row_prefill(  # type: ignore[attr-defined]
+                    logits,
+                    chunk.cu_seqlen_ks,
+                    chunk.cu_seqlen_ke,
+                    topk_dst,
+                    num_rows,
+                    logits.stride(0),
+                    logits.stride(1),
+                    select_k,
+                )
+            else:
+                torch.ops._C.top_k_per_row_prefill("""
+
+
+def main():
+    src = TARGET.read_text()
+
+    # 1. helpers (anchor must appear once)
+    assert src.count(ANCHOR_HELPERS) == 1, "anchor RADIX_TOPK_WORKSPACE_SIZE not unique"
+    src = src.replace(ANCHOR_HELPERS, HELPERS, 1)
+
+    # 2. decode
+    assert src.count(DECODE_OLD) == 1, "decode hunk not found/unique"
+    src = src.replace(DECODE_OLD, DECODE_NEW, 1)
+
+    # 3. prefill
+    assert src.count(PREFILL_OLD) == 1, "prefill hunk not found/unique"
+    src = src.replace(PREFILL_OLD, PREFILL_NEW, 1)
+
+    TARGET.write_text(src)
+    print("PATCH_OK: _torch_decode_topk/_torch_prefill_topk wired into kpool indexer")
+    # sanity
+    assert "_USE_TORCH_TOPK" in src
+    assert src.count("_torch_decode_topk") >= 2
+    assert src.count("_torch_prefill_topk") >= 2
+    print("SANITY_OK: helpers + both call sites present")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/SM121-CRASH-FORENSICS-2026-08-27.md
+++ b/docs/SM121-CRASH-FORENSICS-2026-08-27.md
@@ -49,6 +49,14 @@ decode step now completes ("DEEP-DECODE-OK"), engine healthy after.
 **Upstream ask:** `topk.cu:138` should fall back to a multi-wave persistent variant
 instead of raising when smem < 128KB.
 
+> **Cleaner Disease-1 fix (verified 2026-08-28):** the SM-count gate above works but routes
+> small-SM parts onto the fallback kernel. A second, cleaner fix — routing the fused top-k
+> through **exact `torch.topk`** on sm_12x, matching upstream vLLM PR #49897 and the
+> `dots3-note-gb10-vllm` runtime — is in [`TOPK-OVERSUSCRIPTION-FIX.md`](TOPK-OVERSUSCRIPTION-FIX.md)
+> (`docker/topkfix/patch_kpool_topk.py`). Verified live: 4/4 concurrent long-context requests
+> clean, no `EngineDeadError`. If you use the topkfix image, **do not** bind-mount
+> `sparse_attn_indexer_kpool_sm121.py` — the baked-in fix would be overwritten.
+
 ## Disease 2 — phantom KV backing above ~16 GiB/rank on TP4
 
 With disease 1 patched, a second failure surfaced: at 24 GiB/rank KV, combined load

--- a/docs/TOPK-OVERSUSCRIPTION-FIX.md
+++ b/docs/TOPK-OVERSUSCRIPTION-FIX.md
@@ -1,0 +1,102 @@
+# GLM-5.3-Flash TopK oversubscription — exact `torch.topk` routing fix
+
+**Status: SHIPPED AND VERIFIED LIVE on a 4-Spark GB10 fleet (2026-08-28).** This is the
+second, cleaner fix for **Disease 1** (`persistent_topk` smem wall) documented in
+[`SM121-CRASH-FORENSICS-2026-08-27.md`](SM121-CRASH-FORENSICS-2026-08-27.md). Where the
+original fix gated the fused top-k kernels behind an SM-count check (forcing small-SM parts
+onto the fallback kernel), this fix routes the fused top-k **through exact `torch.topk`** on
+sm_12x — the approach upstream vLLM itself converged on (PR #49897) and the community
+`dots3-note-gb10-vllm` runtime uses. Chat canary OK, **4/4 concurrent long-context requests
+OK**, engine clean (no `EngineDeadError` / topk errors) after load.
+
+## Why the fleet still crashed (recap of Disease 1)
+
+GLM-5.3-Flash uses a **kpool** sparse-attention indexer (`sparse_attn_indexer_kpool.py`,
+`index_topk=2048`, `index_kpool=4` → `select_k = 512`). On GB10 (sm_121, 48 SMs, ~99 KB /
+101376 B smem per block), the fused top-k kernels are unusable:
+
+- `torch.ops._C.persistent_topk` (decode) and `torch.ops._C.top_k_per_row_prefill` (prefill)
+  launch CTAs proportional to the **logits width == `max_model_len`**, not the prompt length.
+- At large context, `total_ctas` exceeds GB10's 48 SMs, tripping a `FilteredTopK` fallback
+  that requires **≥128 KB smem/block** — SM121 has only 101376 B.
+- Crash: `RuntimeError: launch_persistent_topk, topk.cu: persistent_topk would oversubscribe
+  and the FilteredTopK fallback requires >=128KB smem per block (have 101376).
+  total_ctas=60 > num_sms*occupancy=48 (TopK=512)` → `EngineDeadError` → endpoint dead.
+
+## Why this is the cleaner fix than the SM-count gate
+
+The shipped `sparse_attn_indexer_kpool_sm121.py` gate forces small-SM parts onto the existing
+`top_k_per_row_decode` fallback. It works but:
+
+- **Depends on SM-count detection** and uses the fallback kernel rather than the intended path.
+- The prefill `top_k_per_row_prefill` path was not addressed the same way.
+- It diverges from the direction upstream took (exact `torch.topk`).
+
+## The fix — `docker/topkfix/patch_kpool_topk.py`
+
+A small Python patcher applied at image build. It:
+
+1. Adds `_USE_TORCH_TOPK = current_platform.is_device_capability_family(120)` (sm_12x only).
+2. Adds `_torch_decode_topk` and `_torch_prefill_topk` — exact `torch.topk` replacements that
+   mask invalid positions with `-inf`, run `torch.topk(masked, k, dim=-1)`, and preserve the
+   `-1` padding sentinel (the downstream `expand_pools_and_append_tail` recognizes `tok < 0`).
+3. Wires them into **both** call sites in `sparse_attn_indexer_kpool.py` (decode before
+   `persistent_topk`, prefill before `top_k_per_row_prefill`), passing the **exact same
+   arguments** the fused kernels received so the pool-granular masking contract is preserved.
+4. On non-sm_12x, behavior is byte-identical to stock (fused branches untouched).
+
+**kpool-specific note:** logits/seq_lens are **pool-granular** (compress_ratio ==
+`index_kpool`); selection is on pools (`select_k = topk_tokens // index_kpool`), matching the
+kernel contract. This is the crucial difference from the community `dots3-note-gb10-vllm`
+patch, which targets the **non-kpool** `sparse_attn_indexer.py` and does **not** fix GLM-5.3.
+
+### Build (overlay, ~40 s/node)
+
+```bash
+# Base = the existing DFlash2 overlay image already on your nodes.
+FROM ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v11-dflash2
+ARG VLLM=/usr/local/lib/python3.12/dist-packages/vllm
+COPY docker/topkfix/patch_kpool_topk.py /tmp/patch_kpool_topk.py
+RUN python3 /tmp/patch_kpool_topk.py && \
+    python3 -c "import ast,pathlib; p=pathlib.Path('$VLLM/model_executor/layers/sparse_attn_indexer_kpool.py'); ast.parse(p.read_text()); t=p.read_text(); assert '_USE_TORCH_TOPK' in t and t.count('_torch_decode_topk')>=2 and t.count('_torch_prefill_topk')>=2, 'topkfix markers missing'; print('topkfix apply + AST check OK')"
+```
+
+```bash
+cd docker/topkfix && docker build -t ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v12-dflash2-topkfix .
+```
+
+Because the patch touches only ONE file, distribute by pushing the patcher + Dockerfile to
+each node and building the tiny overlay from each node's **existing local base** (base layers
+are shared → ~40 s). Do **not** `docker save | docker load` a full 31 GB image across the
+fleet (collapses to ~2 MB/s through a relay and crawls).
+
+### Launcher
+
+[`launch-glm53-tp4-dflash2-topkfix.sh`](../launch-glm53-tp4-dflash2-topkfix.sh) — drop-in for
+`launch-glm53-tp4-24g.sh` using the topkfix image. **Crucially it does NOT bind-mount
+`sparse_attn_indexer_kpool_sm121.py`** — the torch.topk fix is baked into the image, and a
+bind-mount would overwrite it. Launch worker-first (rank 3→2→1→0, head last).
+
+## Verification (live, 2026-08-28)
+
+- `docker inspect` → image `sm121-v12-dflash2-topkfix`.
+- Resolved `Glm5NextForConditionalGeneration` + `DFlash2DraftModel`, Eagle3 aux layers
+  `(6,15,25,34,43)`, spec-decode warmup completed.
+- Chat canary returns "OK".
+- **Stress probe:** 4 concurrent ~2000-token-prompt requests all completed OK (5.7–6.4 s
+  each), healthy after — the shape that previously killed the engine now passes.
+- `docker logs --since`: clean (no `persistent_topk` / `oversubscribe` / `EngineDeadError`).
+
+## Upstream context
+
+- Upstream vLLM PR **#49897** (SM12x prefill top-k through `torch.topk`) — still open.
+- Issue **#49896** (SM12x `top_k_per_row_prefill` NaN/garbage → illegal memory access) — open.
+- Issue **#51782** (`persistent_topk` silently drops top-k candidates on coarse histogram
+  bins) — open; a *correctness* defect beyond the crash, and another reason exact `torch.topk`
+  is the right routing on sm_12x.
+- Community `jjang-ai/dots3-note-gb10-vllm` uses the same `torch.topk` routing for the
+  **non-kpool** indexer; this patches the **kpool** indexer GLM-5.3 actually uses.
+
+## Rollback
+
+Rel launch with `launch-glm53-tp4-24g.sh` (the SM-count gate + `sm121-v11-dflash2` image).

--- a/launch-glm53-tp4-dflash2-topkfix.sh
+++ b/launch-glm53-tp4-dflash2-topkfix.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+# GLM-5.3-Flash-NVFP4, TP4, DFlash2 spec decode — with the exact torch.topk top-k fix
+# baked into the image. This is the launcher for the sm121-v12-dflash2-topkfix image,
+# which replaces the Disease-1 SM-count gate (sparse_attn_indexer_kpool_sm121.py
+# bind-mount) with exact torch.topk routing — see docs/TOPK-OVERSUSCRIPTION-FIX.md.
+#
+# NOTE: do NOT bind-mount $HOME/patches/sparse_attn_indexer_kpool.py with this image —
+# the torch.topk fix is baked in and a bind-mount would overwrite it.
+#
+# Head = Reddie (192.168.192.2). EDIT FOR YOUR FABRIC: MODEL_HOST_PATH, the rank->IP
+# map, and the NCCL block. --memory 112g assumes 128 GB nodes.
+# PREREQS on every node:
+#   /var/tmp/models/GLM-5.3-Flash-DFlash2/   <- the drafter weights
+#   $MODEL_HOST_PATH/chat_template_mm.jinja  <- required for vision (mount is :ro)
+# Launch WORKER-FIRST: 3 -> 2 -> 1 -> head 0.
+NODE_RANK="${1:?usage: launch-glm53-tp4-dflash2-topkfix.sh <0|1|2|3>}"
+
+IMAGE="ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v12-dflash2-topkfix"
+NAME="vllm_glm53"
+MODEL_HOST_PATH="/var/tmp/models/keys-glm-5.3-flash-nvfp4-ablit-l15-45-anchorstock"
+MODEL_PATH="/models/glm-5.3-flash-nvfp4"
+CACHE_HOST_PATH="/var/tmp/glm53-vllm-cache"
+HEAD_IP="192.168.192.2"
+MPORT="29521"
+PORT="8000"
+SERVED_NAME="glm-5.3-flash"
+
+case "$NODE_RANK" in
+  0) HOST_IP=192.168.192.2; HEADLESS="" ;;
+  1) HOST_IP=192.168.192.4; HEADLESS="--headless" ;;
+  2) HOST_IP=192.168.192.3; HEADLESS="--headless" ;;
+  3) HOST_IP=192.168.192.1; HEADLESS="--headless" ;;
+  *) echo "rank must be 0-3" >&2; exit 2 ;;
+esac
+
+test -f "$MODEL_HOST_PATH/config.json"       || { echo "MISSING: $MODEL_HOST_PATH/config.json" >&2; exit 3; }
+test -f "$MODEL_HOST_PATH/chat_template_mm.jinja" || { echo "MISSING: chat_template_mm.jinja in the weights dir (vision will 500)" >&2; exit 3; }
+test -f /var/tmp/models/GLM-5.3-Flash-DFlash2/config.json || { echo "MISSING: drafter weights at /var/tmp/models/GLM-5.3-Flash-DFlash2" >&2; exit 3; }
+mkdir -p "$CACHE_HOST_PATH"
+docker rm -f "$NAME" 2>/dev/null || true
+
+docker run --gpus all -d \
+  --name "$NAME" --restart no \
+  --network host --ipc host --shm-size 32g --memory 112g --memory-swap 112g \
+  --ulimit memlock=-1:-1 --cap-add IPC_LOCK \
+  --device /dev/infiniband:/dev/infiniband \
+  -v "$MODEL_HOST_PATH:$MODEL_PATH:ro" \
+  -v /var/tmp/models/GLM-5.3-Flash-DFlash2:/models/dflash2-draft:ro \
+  -v "$CACHE_HOST_PATH:/cache" \
+  -e VLLM_HOST_IP=$HOST_IP \
+  -e HF_HOME=/cache/huggingface \
+  -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 \
+  -e VLLM_ENGINE_READY_TIMEOUT_S=3600 \
+  -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+  -e TORCH_CUDA_ARCH_LIST=12.1a -e FLASHINFER_CUDA_ARCH_LIST=12.1a \
+  -e FLASHINFER_DISABLE_VERSION_CHECK=1 \
+  -e NCCL_NET=IB -e NCCL_IB_DISABLE=0 \
+  -e NCCL_IB_HCA=rocep1s0f0 -e NCCL_IB_GID_INDEX=3 \
+  -e NCCL_IB_ROCE_VERSION_NUM=2 -e NCCL_IB_ADDR_FAMILY=AF_INET \
+  -e NCCL_IB_ADDR_RANGE=192.168.192.0/24 \
+  -e NCCL_SOCKET_IFNAME=enp1s0f0np0 -e GLOO_SOCKET_IFNAME=enp1s0f0np0 \
+  -e TP_SOCKET_IFNAME=enp1s0f0np0 -e MN_IF_NAME=enp1s0f0np0 \
+  -e NCCL_NVLS_ENABLE=0 -e NCCL_CROSS_NIC=0 -e NCCL_IB_MERGE_NICS=0 \
+  -e NCCL_CUMEM_ENABLE=0 -e NCCL_IGNORE_CPU_AFFINITY=1 -e NCCL_DEBUG=WARN \
+  -e TORCH_NCCL_ASYNC_ERROR_HANDLING=1 \
+  "$IMAGE" \
+    "$MODEL_PATH" \
+    --served-model-name "$SERVED_NAME" \
+    --host 0.0.0.0 --port "$PORT" \
+    --trust-remote-code \
+    --tensor-parallel-size 4 \
+    --gpu-memory-utilization 0.72 \
+    --max-model-len 1048576 --max-num-seqs 16 --block-size 2304 \
+    --moe-backend marlin \
+    --speculative-config '{"method":"dflash","model":"/models/dflash2-draft","num_speculative_tokens":7}' \
+    --kv-cache-dtype fp8_e4m3 --kv-cache-memory 25769803776 \
+    --enforce-eager \
+    --tool-call-parser glm47 --enable-auto-tool-choice \
+    --reasoning-parser glm45 \
+    --chat-template "$MODEL_PATH/chat_template_mm.jinja" \
+    --default-chat-template-kwargs '{"enable_thinking": false}' \
+    --distributed-executor-backend mp \
+    --nnodes 4 --node-rank "$NODE_RANK" \
+    --master-addr "$HEAD_IP" --master-port "$MPORT" \
+    $HEADLESS
+
+echo "launched $NAME rank=$NODE_RANK host=$HOST_IP tp4-dflash2-topkfix port=$PORT name=$SERVED_NAME"
+sleep 2
+docker ps --format '{{.Names}} {{.Status}}' | grep "$NAME" || {
+  echo "$NAME exited; inspect with: docker logs $NAME" >&2
+  exit 1
+}


### PR DESCRIPTION
## What & why

This is the **cleaner second fix for Disease 1** (`persistent_topk` smem wall) from
[`docs/SM121-CRASH-FORENSICS-2026-08-27.md`](docs/SM121-CRASH-FORENSICS-2026-08-27.md).

The shipped SM-count gate routes small-SM parts onto the fallback kernel. This routes the
fused `persistent_topk` / `top_k_per_row_prefill` **through exact `torch.topk`** on sm_12x
instead — the approach upstream vLLM converged on (PR #49897) and the community
`jjang-ai/dots3-note-gb10-vllm` runtime uses.

**Why ours is different from the dots3 patch:** dots3 patches the **non-kpool**
`sparse_attn_indexer.py`, which does **not** apply to GLM-5.3. GLM-5.3 uses the **kpool**
indexer (`sparse_attn_indexer_kpool.py`, `select_k = topk_tokens // index_kpool`), so this
fix adapts the torch.topk routing to the pool-granular masking contract.

## What's included

| File | Purpose |
|---|---|
| `docker/topkfix/patch_kpool_topk.py` | String-anchored patcher for `sparse_attn_indexer_kpool.py` (both decode + prefill call sites) |
| `docker/topkfix/Dockerfile` | Overlay on `sm121-v11-dflash2` (~40 s/node) |
| `docs/TOPK-OVERSUSCRIPTION-FIX.md` | Root cause, build, verification |
| `launch-glm53-tp4-dflash2-topkfix.sh` | Launcher — **no SM-count bind-mount** (baked-in fix would be overwritten) |
| README + forensics cross-refs | Discoverability |

## Verification (live, 2026-08-28, 4-Spark GB10 fleet)

- Image `sm121-v12-dflash2-topkfix`; `Glm5NextForConditionalGeneration` + `DFlash2DraftModel`
  resolved, Eagle3 aux `(6,15,25,34,43)`, spec-decode warmup done.
- Chat canary OK; **4/4 concurrent ~2000-token-prompt requests** completed (5.7-6.4 s each).
- `docker logs`: no `persistent_topk` / `oversubscribe` / `EngineDeadError`.

## Rollback

Relaunch with `launch-glm53-tp4-24g.sh` (SM-count gate + `sm121-v11-dflash2`).