### PR TITLE
TP4 speed run: aggregate +175%, prefill +56% from two flags

### DIFF
--- a/docs/SPEED-RUN-2026-08-31.md
+++ b/docs/SPEED-RUN-2026-08-31.md
@@ -4,8 +4,11 @@ An overnight tuning pass on the shipping TP4 recipe. Every number here is **temp
 fixed prompts, median of repeats, measured with
 [`probes/bench_glm53_tp4.py`](../probes/bench_glm53_tp4.py) on the production 4-Spark fleet.
 
-**Headline: aggregate throughput 183 → 503 tok/s (+175%) and prefill +52-79%, from two flags.
-Two heavily recommended flags were tested and both made things worse.**
+**Headline: aggregate throughput 183 → 530 tok/s (+190%) and prefill +52-79%.**
+
+> **Read §4 first if you are here for the CUDA-graph question.** This document originally
+> concluded that `--enforce-eager` should stay. That was wrong — it tested the wrong graph
+> mode. `FULL_AND_PIECEWISE` beats eager on every metric and is now the shipped default.
 
 ---
 
@@ -148,7 +151,36 @@ speed gain is a bad deal on a production endpoint.
 
 ---
 
-## 4 — `--enforce-eager` is load-bearing. Keep it. (rejected PIECEWISE)
+## 4 — CORRECTED: graphs win, I tested the wrong mode
+
+> **Correction, 2026-09-02.** The section below concluded "`--enforce-eager` is
+> load-bearing, keep it." **That conclusion is wrong.** The measurement was real but it
+> tested plain **`PIECEWISE`**, which forces piecewise graphs onto the *decode* path.
+> **`FULL_AND_PIECEWISE`** — FULL for uniform decode batches, piecewise only for
+> mixed/prefill — is faster than eager on every prompt type:
+>
+> | prompt | eager | **FULL_AND_PIECEWISE** |
+> |---|---|---|
+> | count-to-100 | 101.64 | **105.58** |
+> | code | 72.03 | **77.32** |
+> | prose | 26.92 | **31.53** |
+> | best aggregate | 503.28 | **530.01** |
+>
+> Credit to @1890peachypeachy (#5) for the finding and, more importantly, for the framing
+> I missed: **`--enforce-eager` is a property of the NVFP4-KV/b12x lane, not of the model.**
+> The b12x kernels require it; marlin does not. The recipe carried it as a blanket "required
+> by the b12x kernels," and that is why it sat unexploited.
+>
+> I talked myself out of testing `FULL_AND_PIECEWISE` on the strength of vLLM #40969
+> reporting it hanging on DeepSeek-V4-Flash. That report does not transfer here. Reasoning
+> from someone else's stack instead of measuring my own is the actual mistake, and it cost
+> a ~5% aggregate and ~17% prose gain for two days.
+>
+> It *does* hang with the topkfix image (docs/TOPK-OVERSUSCRIPTION-FIX.md) — so eager is
+> still correct on that lane, and on b12x. The original analysis below is kept for the
+> record.
+
+## 4 (original, superseded) — `--enforce-eager` is load-bearing. Keep it. (rejected PIECEWISE)
 
 This is the most consequential result of the run, because the recipe's `--enforce-eager`
 is widely characterised as unsourced folklore — including in the sibling repo's

--- a/docs/SPEED-RUN-2026-08-31.md
+++ b/docs/SPEED-RUN-2026-08-31.md
@@ -4,7 +4,7 @@ An overnight tuning pass on the shipping TP4 recipe. Every number here is **temp
 fixed prompts, median of repeats, measured with
 [`probes/bench_glm53_tp4.py`](../probes/bench_glm53_tp4.py) on the production 4-Spark fleet.
 
-**Headline: aggregate throughput 183 → 503 tok/s (+175%) and prefill +56%, from two flags.
+**Headline: aggregate throughput 183 → 503 tok/s (+175%) and prefill +52-79%, from two flags.
 Two heavily recommended flags were tested and both made things worse.**
 
 ---
@@ -33,14 +33,24 @@ Two heavily recommended flags were tested and both made things worse.**
 Two flags. Everything else unchanged — `--enforce-eager` **kept** (see 04), DFlash2 k=7,
 block-size 2304, marlin, fp8_e4m3 KV, 24 GiB/rank, gpu-mem-util 0.85.
 
-| metric | baseline | shipped | change |
+| metric | baseline | shipped (verified as serving) | change |
 |---|---|---|---|
 | **aggregate throughput (best)** | 183.1 @C6 | **503.3 @C48** | **+175%** |
-| **prefill @114K prompt** | 1,194 tok/s | **1,863 tok/s** | **+56%** |
-| **TTFT @114K prompt** | 95.4 s | **61.2 s** | **−36%** |
-| **PEAK decode (count-to-100)** | 102.15 | **102.81** | +0.6% |
-| decode, code | 70.46 | 66.90 | −5.1% |
-| decode, dense prose | 26.37 | 27.74 | +5.2% |
+| **prefill, warmed @13.6K** | 1,171 tok/s | **2,092 tok/s** | **+78.7%** |
+| **prefill, warmed @56K** | 1,372 tok/s | **2,091 tok/s** | **+52.4%** |
+| **prefill, warmed @114K** | 1,194 tok/s | **2,080 tok/s** | **+74.2%** |
+| **TTFT @114K prompt** | 95.4 s | **54.8 s** | **−42.6%** |
+| **PEAK decode (count-to-100)** | 102.15 | **101.64** (peak 103.33) | flat |
+| decode, code | 70.46 | 72.03 | +2.2% |
+| decode, dense prose | 26.37 | 26.92 | +2.1% |
+
+Prefill is **flat at ~2,085 tok/s across every prompt size**, where the baseline sagged at
+both ends (1,171 / 1,372 / 1,194).
+
+> **Measure prefill warmed, or not at all.** Because each experiment here got its own
+> `VLLM_CACHE_ROOT` (needed to isolate k sweeps — vLLM #53366), every boot starts with a
+> cold FlashInfer autotune cache and the first large prefills pay JIT. An unwarmed pass on
+> the shipped config returned 755 / 2032 / 1173 tok/s; warmed it returns 2092 / 2091 / 2080.
 
 Gate-passed at 113,918-token prompts, C1 and C2, zero failures (per-stream 38.05 / 18.25).
 

--- a/docs/SPEED-RUN-2026-08-31.md
+++ b/docs/SPEED-RUN-2026-08-31.md
@@ -20,6 +20,7 @@ Two heavily recommended flags were tested and both made things worse.**
 | 05 | `--max-num-seqs` 128 + batched 16384 | partial | best peak (540 @C96) but worse latency |
 | 06 | `--max-num-seqs` 64 + batched 16384 | **SHIPPED** | prefill +52-79% (warmed), aggregate +175% |
 | 07 | dynamic k schedule | tied | neutral; see noise calibration below |
+| 10 | NCCL `ALGO=Tree PROTO=LL` | **fatal** | all 4 ranks fail to init — see below |
 
 ### The shipped config
 
@@ -262,6 +263,38 @@ unchanged versus static k=7. The four extra draft positions contribute *nothing 
 that concurrency — the tokens they win are cancelled by the verify compute they cost on a
 288-expert MoE. Dynamic k therefore buys the same throughput for less compute, which is
 worth revisiting beyond C48 where it should start winning outright rather than drawing.
+
+## 10 — a global `NCCL_ALGO=Tree` pin is fatal here
+
+Attempted as the last decode-latency lever: decode all-reduce on this model is ~16-64 KB,
+which NVIDIA's tuning table places at Tree+LL. **All four ranks failed to initialise.**
+
+```
+enqueue.cc:2064 (topoGetAlgoInfo) NCCL WARN
+  No algorithm/protocol available for function AllGather with datatype ncclInt8.
+  NCCL_ALGO=Tree NCCL_PROTO=LL
+RuntimeError: NCCL error: invalid usage
+```
+
+It dies in `gpu_worker.determine_available_memory -> model_runner.profile_run()`, at the
+first collective. Not an OOM: the head rank had 116 GiB free, 0.2 GiB cached, zero
+`NV_ERR_NO_MEMORY`.
+
+**Root cause:** `NCCL_ALGO=Tree` has no AllGather implementation — Tree covers AllReduce,
+Broadcast and Reduce. A *global* `NCCL_ALGO` pin applies to every collective, and vLLM
+issues AllGathers, so NCCL finds no valid algo/protocol pair and raises.
+
+The tuning guidance being applied is about **AllReduce** message sizes. The correct form
+is per-function scoping, which is what should be tested next:
+
+```bash
+NCCL_ALGO=allreduce:tree    # NOT a bare NCCL_ALGO=Tree
+NCCL_PROTO=LL               # PROTO alone is safe; ALGO is what breaks AllGather
+```
+
+Untested, and worth an `all_reduce_perf -b 8K -e 1M` A/B before another serving attempt —
+LL over RoCE does per-8-byte flag sync, which may outweigh the latency win at inter-node
+scale.
 
 ## Method
 

--- a/docs/SPEED-RUN-2026-08-31.md
+++ b/docs/SPEED-RUN-2026-08-31.md
@@ -18,6 +18,7 @@ recommended flags were tested and both made things worse.**
 | 03 | `use_local_argmax_reduction: true` | **reject** | −13% at C32 |
 | 04 | `--enforce-eager` → `cudagraph_mode: PIECEWISE` | **reject** | −19% single stream |
 | 05 | `--max-num-seqs` 128 + batched 16384 | partial | best peak (540 @C96) but worse latency |
+| 07 | dynamic k schedule | tied | neutral; see noise calibration below |
 | 06 | `--max-num-seqs` 64 + batched 16384 | **SHIPPED** | prefill +56%, aggregate +175% |
 
 ### The shipped config
@@ -223,6 +224,34 @@ The second concurrent request costs 5% more wall time. Aggregate scales 1.9x, pe
 halves — just fair sharing. Only C1 and C2 were tested; the cliff may exist further out.
 
 ---
+
+## 07 — dynamic k (tested, tied, not shipped) — and a noise calibration
+
+`num_speculative_tokens_per_batch_size: [[1,8,7],[9,32,5],[33,512,3]]` on top of the
+shipped config:
+
+| | count100 | code | prose | C8 | C16 | C32 | C48 |
+|---|---|---|---|---|---|---|---|
+| shipped (static k=7) | 102.81 | 66.90 | 27.74 | 203.2 | 261.6 | 389.2 | **503.3** |
+| dynamic k | 102.23 | 75.91 | 24.65 | 205.3 | 267.1 | 389.8 | 500.1 |
+
+**Read this as a tie — and as a measurement of the harness's own noise.** The schedule's
+first tier is `[1,8,7]`, i.e. batch 1–8 gets k=7, which is *exactly* the shipped static
+config. So at concurrency 1 these two runs are the same configuration, and the code
++13.5% / prose −11.1% swing between them is pure run-to-run variance.
+
+> **Calibration, applies to every single-stream number in this document:** medians of 3
+> carry roughly **±10% spread** on this fleet. Sub-10% single-stream differences are not
+> resolvable and should not be read as effects. The aggregate columns behave better but
+> were only 2 rounds. The two shipped flags clear this bar by a wide margin (+175%, +56%);
+> the two rejected ones fail it in the wrong direction by ~13–19%, which is also outside
+> the band.
+
+**One real result underneath the noise:** at C48 the schedule serves k=3 and aggregate is
+unchanged versus static k=7. The four extra draft positions contribute *nothing net* at
+that concurrency — the tokens they win are cancelled by the verify compute they cost on a
+288-expert MoE. Dynamic k therefore buys the same throughput for less compute, which is
+worth revisiting beyond C48 where it should start winning outright rather than drawing.
 
 ## Method
 

--- a/docs/SPEED-RUN-2026-08-31.md
+++ b/docs/SPEED-RUN-2026-08-31.md
@@ -4,8 +4,8 @@ An overnight tuning pass on the shipping TP4 recipe. Every number here is **temp
 fixed prompts, median of repeats, measured with
 [`probes/bench_glm53_tp4.py`](../probes/bench_glm53_tp4.py) on the production 4-Spark fleet.
 
-**Headline: aggregate throughput 183 → 519 tok/s (2.84x) from one flag. Two heavily
-recommended flags were tested and both made things worse.**
+**Headline: aggregate throughput 183 → 503 tok/s (+175%) and prefill +56%, from two flags.
+Two heavily recommended flags were tested and both made things worse.**
 
 ---
 
@@ -18,8 +18,8 @@ recommended flags were tested and both made things worse.**
 | 03 | `use_local_argmax_reduction: true` | **reject** | −13% at C32 |
 | 04 | `--enforce-eager` → `cudagraph_mode: PIECEWISE` | **reject** | −19% single stream |
 | 05 | `--max-num-seqs` 128 + batched 16384 | partial | best peak (540 @C96) but worse latency |
-| 07 | dynamic k schedule | tied | neutral; see noise calibration below |
 | 06 | `--max-num-seqs` 64 + batched 16384 | **SHIPPED** | prefill +56%, aggregate +175% |
+| 07 | dynamic k schedule | tied | neutral; see noise calibration below |
 
 ### The shipped config
 

--- a/docs/SPEED-RUN-2026-08-31.md
+++ b/docs/SPEED-RUN-2026-08-31.md
@@ -1,0 +1,241 @@
+# TP4 speed run — 2026-08-31
+
+An overnight tuning pass on the shipping TP4 recipe. Every number here is **temperature 0**,
+fixed prompts, median of repeats, measured with
+[`probes/bench_glm53_tp4.py`](../probes/bench_glm53_tp4.py) on the production 4-Spark fleet.
+
+**Headline: aggregate throughput 183 → 519 tok/s (2.84x) from one flag. Two heavily
+recommended flags were tested and both made things worse.**
+
+---
+
+## What changed, and what it bought
+
+| # | Change | Verdict | Effect |
+|---|---|---|---|
+| 01 | `--max-num-seqs` 6 → 24 | **adopt** | aggregate +82.7% |
+| 02 | `--max-num-seqs` 24 → 64 | **adopt** | aggregate +183.5% vs baseline |
+| 03 | `use_local_argmax_reduction: true` | **reject** | −13% at C32 |
+| 04 | `--enforce-eager` → `cudagraph_mode: PIECEWISE` | **reject** | −19% single stream |
+| 05 | `--max-num-seqs` 128 + batched 16384 | partial | best peak (540 @C96) but worse latency |
+| 06 | `--max-num-seqs` 64 + batched 16384 | **SHIPPED** | prefill +56%, aggregate +175% |
+
+### The shipped config
+
+```diff
+- --max-num-seqs 6
++ --max-num-seqs 64
+- --max-num-batched-tokens 8192
++ --max-num-batched-tokens 16384
+```
+
+Two flags. Everything else unchanged — `--enforce-eager` **kept** (see 04), DFlash2 k=7,
+block-size 2304, marlin, fp8_e4m3 KV, 24 GiB/rank, gpu-mem-util 0.85.
+
+| metric | baseline | shipped | change |
+|---|---|---|---|
+| **aggregate throughput (best)** | 183.1 @C6 | **503.3 @C48** | **+175%** |
+| **prefill @114K prompt** | 1,194 tok/s | **1,863 tok/s** | **+56%** |
+| **TTFT @114K prompt** | 95.4 s | **61.2 s** | **−36%** |
+| **PEAK decode (count-to-100)** | 102.15 | **102.81** | +0.6% |
+| decode, code | 70.46 | 66.90 | −5.1% |
+| decode, dense prose | 26.37 | 27.74 | +5.2% |
+
+Gate-passed at 113,918-token prompts, C1 and C2, zero failures (per-stream 38.05 / 18.25).
+
+Single-stream decode barely moves, and that is the expected result: decode on this
+topology is bandwidth-bound per node and TP4 is already at the useful limit. **The
+headroom was never in single-stream latency — it was in concurrency and prefill, and two
+conservative defaults were leaving both on the table.**
+
+---
+
+## Baseline, for reference
+
+Config as shipped: `--enforce-eager`, DFlash2 k=7, `--max-num-seqs 6`,
+`--max-num-batched-tokens 8192`, `--block-size 2304`, `--moe-backend marlin`,
+fp8_e4m3 KV, 24 GiB/rank.
+
+| prompt | decode tok/s | peak | accept ratio | mean accept len |
+|---|---|---|---|---|
+| count-to-100 (PEAK probe) | **102.15** | 102.30 | 0.956 | 7.69 / 8 |
+| code | 70.46 | 76.08 | 0.665 | 5.65 |
+| dense prose | 26.37 | 28.96 | 0.174 | 2.22 |
+
+Per-position acceptance — this is the whole tuning story:
+
+| pos | 0 | 1 | 2 | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|---|---|---|
+| count-to-100 | 1.000 | 1.000 | 0.974 | 0.962 | 0.962 | 0.910 | 0.885 |
+| code | 0.941 | 0.796 | 0.715 | 0.653 | 0.578 | 0.511 | 0.460 |
+| prose | 0.614 | 0.332 | 0.152 | 0.076 | 0.031 | 0.011 | 0.002 |
+
+On prose, draft positions 4–6 return 0.031 / 0.011 / 0.002 while costing full verify
+compute on a 288-expert MoE. On code the same positions return 0.58 / 0.51 / 0.46 and are
+well worth paying for. **No single static `k` serves both** — which is the argument for
+`num_speculative_tokens_per_batch_size` rather than lowering k globally.
+
+> **These numbers are not comparable to the README's.** The README records ~35 prose /
+> ~57 code. This run measures 26.4 / 70.5. The difference is temperature: acceptance is a
+> function of how predictable the content is, so **temperature is a first-order variable
+> on a spec-decode engine, not a detail.** Any tok/s figure for this model needs its
+> prompt *and* its temperature quoted or it means nothing.
+
+---
+
+## 1 & 2 — `--max-num-seqs` is the aggregate lever
+
+The shipped `--max-num-seqs 6` was the binding constraint on aggregate throughput, not the
+fabric. Baseline aggregate was still climbing monotonically when it hit the cap:
+
+| C | 1 | 2 | 3 | 4 | 5 | 6 |
+|---|---|---|---|---|---|---|
+| baseline agg tok/s | 56.4 | 92.2 | 110.3 | 127.0 | 152.1 | **183.1** ← cap |
+
+Raising it:
+
+| C | 1 | 4 | 8 | 16 | 24 | 32 | 48 |
+|---|---|---|---|---|---|---|---|
+| seqs 24 | 67.3 | 158.9 | 201.5 | 279.2 | — | — | — |
+| **seqs 64** | 65.9 | 111.7 | **224.3** | 249.3 | 361.6 | **430.2** | **519.1** |
+
+**Best aggregate 183.1 → 519.1 tok/s (+183.5%), peak 539.0.**
+
+Single stream is unchanged throughout (count100 102.2 → 98.8, code 70.5 → 73.1, prose
+26.4 → 27.8 — all within run-to-run noise), which is the correct signature: this is a
+scheduler cap and should not touch c1.
+
+The knee is around C32–C48: that step buys +20.7% aggregate for +50% concurrency while
+wall time grows 52 → 65 s. Pick the cap from whether you care about aggregate or tail
+latency.
+
+---
+
+## 3 — `use_local_argmax_reduction` does not work here (rejected)
+
+vLLM [PR #39419](https://github.com/vllm-project/vllm/pull/39419) measures this flag at
+**+30.6% on TP4/c32** for Qwen3-8B + DFlash, by replacing an O(vocab) logits all-gather
+with an O(2·tp_size) local argmax. Our case looked strictly more favourable on paper:
+vocab 154,880, TP4, and the gather crosses 200GbE RDMA rather than PCIe.
+
+Measured, on top of seqs 64:
+
+| C | 1 | 8 | 16 | 32 | 48 |
+|---|---|---|---|---|---|
+| without | 65.9 | **224.3** | 249.3 | **430.2** | **519.1** |
+| with | 63.1 | 184.2 | 251.3 | 374.0 | 482.5 |
+
+Consistent regression, medians and peaks agreeing. **Most likely cause: the flag is
+MRv2-only** (`VLLM_USE_V2_MODEL_RUNNER=1`), which we do not run — MRv2 is default for
+dense models only.
+
+Not pursued further, deliberately: enabling MRv2 to chase it risks a **silent** downgrade,
+since MRv2 falls back to V1 with only a `warning_once` under several conditions, and on V1
+a DFlash2 checkpoint drafts as DFlash1. Trading silent correctness risk for an uncertain
+speed gain is a bad deal on a production endpoint.
+
+---
+
+## 4 — `--enforce-eager` is load-bearing. Keep it. (rejected PIECEWISE)
+
+This is the most consequential result of the run, because the recipe's `--enforce-eager`
+is widely characterised as unsourced folklore — including in the sibling repo's
+[PR #2](https://github.com/tonyd2wild/GLM-5.3-Flash-NVFP4-1M-KV-4x-DGX-Spark/pull/2),
+which recommends `FULL_DECODE_ONLY`.
+
+| | count100 | code | prose | C8 | C32 | C48 |
+|---|---|---|---|---|---|---|
+| eager (shipped) | **98.8** | **73.1** | **27.8** | **224.3** | **430.2** | **519.1** |
+| PIECEWISE | 80.0 | 58.8 | 24.0 | 183.5 | 395.2 | 451.3 |
+| delta | −19.0% | −19.6% | −13.8% | −18.2% | −8.1% | −13.1% |
+
+Plus ~4 minutes of extra startup for capture.
+
+**Why it loses.** Acceptance *improved* slightly under PIECEWISE (code accept ratio
+0.660 → 0.685, mean accepted length 5.62 → 5.80), so the drafter is fine; the whole loss
+is per-step cost. 34 of 45 layers are KDA linear-attention, which vLLM classifies
+`UNIFORM_SINGLE_TOKEN_DECODE` and cannot full-capture — so PIECEWISE must split the graph
+around them, and here the boundaries cost more than the launch overhead they remove.
+Speculative decoding compounds it: the verify batch shape varies with how many of the 7
+draft positions were accepted, so the graph is re-dispatched constantly.
+
+`FULL` and `FULL_AND_PIECEWISE` were not tested. FULL is auto-downgraded for KDA layers,
+and vLLM [#40969](https://github.com/vllm-project/vllm/issues/40969) reports
+`FULL_AND_PIECEWISE` hanging at request 6–7 on the closest analogous stack (DeepSeek-V4-Flash,
+sparse-MLA, dual GB10). With PIECEWISE already losing, there was no case for spending a
+reload on a mode that is both auto-downgraded and reported to hang.
+
+**Corollary: the `+55% from CUDA graphs on SM121` figure that circulates for this hardware
+does not apply to hybrid linear-attention models.** Neither does the +10% measured on
+sparse-MLA. Test it on your own model rather than inheriting either number.
+
+---
+
+## Two bugs found that are not about speed
+
+### Prefix caching never hits
+
+```
+run 1: prefix_cache_queries +495   hits +0
+run 2: prefix_cache_queries +495   hits +0     <- identical 495-token prompt, should hit
+```
+
+Confirms [repo issue #13](https://github.com/tonyd2wild/GLM-5.3-Flash-NVFP4-DFlash2-2x-DGX-Spark/issues/13)
+on TP4 as well as TP2. Mechanism is upstream
+[vLLM #54360](https://github.com/vllm-project/vllm/issues/54360): enabling *any*
+speculative method on a hybrid-GDN model silently drops `prefix_cache_hits_total` to zero.
+So it is **spec-decode × hybrid attention, not SM121**.
+
+Consequence for this repo: the gate advice "vary the prompt per run or the prefix cache
+turns a 30 s gate into a 2 s no-op" is currently moot — nothing is cached while DFlash2
+is on.
+
+### Verifying image *IDs* across ranks produces false alarms
+
+Hard-won rule #3 says to verify `docker image inspect` IDs match on every rank. On this
+fleet all four ranks report **different** image IDs (two registries, two build windows) —
+and it is benign: every `.py` under `vllm/` is byte-identical across ranks, all four run
+the same vLLM hash, and only `.pyc` caches differ. Image ID diverges whenever a layer is
+rebuilt or a file is touched.
+
+The check that answers the actual question:
+
+```bash
+docker exec vllm_glm53 sh -lc 'V=$(python3 -c "import vllm,os;print(os.path.dirname(vllm.__file__))"); \
+  find $V -name "*.py" | sort | xargs md5sum | md5sum'
+```
+
+---
+
+## Long context: the TP2 collapse does not reproduce at TP4
+
+[Issue #14](https://github.com/tonyd2wild/GLM-5.3-Flash-NVFP4-DFlash2-2x-DGX-Spark/issues/14)
+reports that at TP2, two concurrent 25–100K-token requests collapse to ~4 tok/s aggregate.
+At TP4, with 113,918-token prompts:
+
+| | C1 | C2 |
+|---|---|---|
+| per-stream decode | 40.55 tok/s | 21.00 tok/s |
+| wall | 62.4 s | **65.5 s** |
+| failures | 0 | 0 |
+
+The second concurrent request costs 5% more wall time. Aggregate scales 1.9x, per-stream
+halves — just fair sharing. Only C1 and C2 were tested; the cliff may exist further out.
+
+---
+
+## Method
+
+- `probes/bench_glm53_tp4.py` — fixed prompts, temperature 0, streaming so prefill and
+  decode separate, median + P90 + peak, spec acceptance from `/metrics` as both
+  accepted/drafted ratio and mean accepted length, plus per-position.
+- The older `probes/bench_c1c6.py` was not used for config comparison: it runs
+  temperature 1.0 (content variance becomes acceptance variance), reports pooled means,
+  is non-streaming so it cannot split prefill from decode, and has no count-to-100 probe.
+- Reload discipline between every config: tear down all four ranks, unconditional
+  `drop_caches` on every node, worker-first 3→2→1→0, poll `/v1/models`, abort on rank
+  death rather than retry.
+- **Per-experiment `VLLM_CACHE_ROOT`.** vLLM
+  [#53366](https://github.com/vllm-project/vllm/issues/53366): `SpeculativeConfig.compute_hash()`
+  omits `num_speculative_tokens`, so sweeping k in a shared cache dir can silently serve an
+  Inductor artifact compiled for a different k. Any k sweep without this control is suspect.

--- a/docs/SPEED-RUN-2026-08-31.md
+++ b/docs/SPEED-RUN-2026-08-31.md
@@ -18,7 +18,7 @@ Two heavily recommended flags were tested and both made things worse.**
 | 03 | `use_local_argmax_reduction: true` | **reject** | −13% at C32 |
 | 04 | `--enforce-eager` → `cudagraph_mode: PIECEWISE` | **reject** | −19% single stream |
 | 05 | `--max-num-seqs` 128 + batched 16384 | partial | best peak (540 @C96) but worse latency |
-| 06 | `--max-num-seqs` 64 + batched 16384 | **SHIPPED** | prefill +56%, aggregate +175% |
+| 06 | `--max-num-seqs` 64 + batched 16384 | **SHIPPED** | prefill +52-79% (warmed), aggregate +175% |
 | 07 | dynamic k schedule | tied | neutral; see noise calibration below |
 
 ### The shipped config

--- a/docs/speed-run-2026-08-31-results/00-baseline-eager-k7-seqs6.json
+++ b/docs/speed-run-2026-08-31-results/00-baseline-eager-k7-seqs6.json
@@ -1,0 +1,309 @@
+{
+  "label": "00-baseline-eager-k7-seqs6",
+  "started": "2026-08-31 03:35:28",
+  "url": "http://100.113.138.96:8000",
+  "single": {
+    "count100": {
+      "decode_tok_s": {
+        "median": 102.15,
+        "p90": 102.3,
+        "peak": 102.3,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 91.64,
+        "p90": 92.56,
+        "peak": 92.56,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.23,
+        "p90": 0.27,
+        "peak": 0.27,
+        "n": 3
+      },
+      "completion_tokens": 200,
+      "prompt_tokens": 33,
+      "spec": {
+        "accept_ratio": 0.956,
+        "mean_accept_len": 7.692,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.974,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.962,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.962,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.91,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.885
+        }
+      }
+    },
+    "code": {
+      "decode_tok_s": {
+        "median": 70.46,
+        "p90": 76.08,
+        "peak": 76.08,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 68.81,
+        "p90": 72.62,
+        "peak": 72.62,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.33,
+        "p90": 0.45,
+        "peak": 0.45,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 58,
+      "spec": {
+        "accept_ratio": 0.6647,
+        "mean_accept_len": 5.653,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.941,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.796,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.715,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.653,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.578,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.511,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.46
+        }
+      }
+    },
+    "prose": {
+      "decode_tok_s": {
+        "median": 26.37,
+        "p90": 28.96,
+        "peak": 28.96,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 26.14,
+        "p90": 28.71,
+        "peak": 28.71,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.25,
+        "p90": 0.27,
+        "peak": 0.27,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 51,
+      "spec": {
+        "accept_ratio": 0.174,
+        "mean_accept_len": 2.218,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.614,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.332,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.152,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.076,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.031,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.011,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.002
+        }
+      }
+    }
+  },
+  "prefill": {
+    "4096": {
+      "prompt_tokens": 13637,
+      "ttft_s": 11.646,
+      "prefill_tok_s": 1171.0
+    },
+    "16384": {
+      "prompt_tokens": 56195,
+      "ttft_s": 40.96,
+      "prefill_tok_s": 1372.0
+    },
+    "32768": {
+      "prompt_tokens": 113915,
+      "ttft_s": 95.431,
+      "prefill_tok_s": 1193.7
+    }
+  },
+  "sweep": {
+    "c1": {
+      "agg_tok_s": {
+        "median": 56.41,
+        "p90": 61.49,
+        "peak": 61.49,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 12.51,
+        "p90": 13.63,
+        "peak": 13.63,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6624,
+        "mean_accept_len": 5.637,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.948,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.823,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.694,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.625,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.581,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.528,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.44
+        }
+      }
+    },
+    "c2": {
+      "agg_tok_s": {
+        "median": 92.23,
+        "p90": 119.01,
+        "peak": 119.01,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 16.58,
+        "p90": 21.39,
+        "peak": 21.39,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6728,
+        "mean_accept_len": 5.709,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.947,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.815,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.722,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.667,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.587,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.537,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.435
+        }
+      }
+    },
+    "c3": {
+      "agg_tok_s": {
+        "median": 110.29,
+        "p90": 126.35,
+        "peak": 126.35,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 19.45,
+        "p90": 22.28,
+        "peak": 22.28,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6551,
+        "mean_accept_len": 5.585,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.94,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.809,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.713,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.626,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.56,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.501,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.436
+        }
+      }
+    },
+    "c4": {
+      "agg_tok_s": {
+        "median": 127.04,
+        "p90": 142.86,
+        "peak": 142.86,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 22.39,
+        "p90": 25.17,
+        "peak": 25.17,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6276,
+        "mean_accept_len": 5.393,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.797,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.682,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.591,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.522,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.474,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.394
+        }
+      }
+    },
+    "c5": {
+      "agg_tok_s": {
+        "median": 152.13,
+        "p90": 183.4,
+        "peak": 183.4,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 24.02,
+        "p90": 28.96,
+        "peak": 28.96,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6479,
+        "mean_accept_len": 5.535,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.79,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.695,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.621,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.557,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.505,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.433
+        }
+      }
+    },
+    "c6": {
+      "agg_tok_s": {
+        "median": 183.09,
+        "p90": 187.46,
+        "peak": 187.46,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 22.95,
+        "p90": 23.5,
+        "peak": 23.5,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6464,
+        "mean_accept_len": 5.525,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.94,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.802,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.7,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.612,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.546,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.497,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.428
+        }
+      }
+    }
+  },
+  "longctx": {
+    "c1": {
+      "agg_tok_s": 4.01,
+      "per_stream_tok_s": 40.55,
+      "wall_s": 62.4,
+      "prompt_tokens": 113918,
+      "fails": 0
+    },
+    "c2": {
+      "agg_tok_s": 7.64,
+      "per_stream_tok_s": 21.0,
+      "wall_s": 65.5,
+      "prompt_tokens": 113918,
+      "fails": 0
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/01-seqs24.json
+++ b/docs/speed-run-2026-08-31-results/01-seqs24.json
@@ -1,0 +1,330 @@
+{
+  "label": "01-seqs24",
+  "started": "2026-08-31 04:00:38",
+  "url": "http://100.113.138.96:8000",
+  "single": {
+    "count100": {
+      "decode_tok_s": {
+        "median": 101.56,
+        "p90": 102.63,
+        "peak": 102.63,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 91.2,
+        "p90": 92.43,
+        "peak": 92.43,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.25,
+        "p90": 0.27,
+        "peak": 0.27,
+        "n": 3
+      },
+      "completion_tokens": 200,
+      "prompt_tokens": 33,
+      "spec": {
+        "accept_ratio": 0.9524,
+        "mean_accept_len": 7.667,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.987,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.987,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.987,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.962,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.872,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.872
+        }
+      }
+    },
+    "code": {
+      "decode_tok_s": {
+        "median": 72.86,
+        "p90": 75.22,
+        "peak": 75.22,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 71.16,
+        "p90": 73.26,
+        "peak": 73.26,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.26,
+        "p90": 0.26,
+        "peak": 0.26,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 58,
+      "spec": {
+        "accept_ratio": 0.6761,
+        "mean_accept_len": 5.733,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.956,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.826,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.755,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.668,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.572,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.518,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.439
+        }
+      }
+    },
+    "prose": {
+      "decode_tok_s": {
+        "median": 25.18,
+        "p90": 28.93,
+        "peak": 28.93,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 25.04,
+        "p90": 28.64,
+        "peak": 28.64,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.25,
+        "p90": 0.28,
+        "peak": 0.28,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 51,
+      "spec": {
+        "accept_ratio": 0.1848,
+        "mean_accept_len": 2.294,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.631,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.34,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.192,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.078,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.031,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.015,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.008
+        }
+      }
+    }
+  },
+  "sweep": {
+    "c1": {
+      "agg_tok_s": {
+        "median": 67.31,
+        "p90": 69.71,
+        "peak": 69.71,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 10.41,
+        "p90": 10.78,
+        "peak": 10.78,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6488,
+        "mean_accept_len": 5.542,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.929,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.798,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.7,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.628,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.561,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.506,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.419
+        }
+      }
+    },
+    "c2": {
+      "agg_tok_s": {
+        "median": 84.47,
+        "p90": 105.18,
+        "peak": 105.18,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 17.63,
+        "p90": 21.96,
+        "peak": 21.96,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6385,
+        "mean_accept_len": 5.47,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.942,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.797,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.692,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.612,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.534,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.481,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.411
+        }
+      }
+    },
+    "c4": {
+      "agg_tok_s": {
+        "median": 158.91,
+        "p90": 159.45,
+        "peak": 159.45,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 17.62,
+        "p90": 17.68,
+        "peak": 17.68,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6406,
+        "mean_accept_len": 5.484,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.938,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.797,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.684,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.602,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.538,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.495,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.431
+        }
+      }
+    },
+    "c6": {
+      "agg_tok_s": {
+        "median": 162.29,
+        "p90": 183.08,
+        "peak": 183.08,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 26.31,
+        "p90": 29.68,
+        "peak": 29.68,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.629,
+        "mean_accept_len": 5.403,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.791,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.683,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.598,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.52,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.469,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.409
+        }
+      }
+    },
+    "c8": {
+      "agg_tok_s": {
+        "median": 201.51,
+        "p90": 230.26,
+        "peak": 230.26,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 28.37,
+        "p90": 32.42,
+        "peak": 32.42,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6407,
+        "mean_accept_len": 5.485,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.943,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.798,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.69,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.614,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.541,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.48,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.418
+        }
+      }
+    },
+    "c12": {
+      "agg_tok_s": {
+        "median": 258.25,
+        "p90": 269.66,
+        "peak": 269.66,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 32.59,
+        "p90": 34.03,
+        "peak": 34.03,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6426,
+        "mean_accept_len": 5.498,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.938,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.797,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.689,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.614,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.55,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.492,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.418
+        }
+      }
+    },
+    "c16": {
+      "agg_tok_s": {
+        "median": 279.24,
+        "p90": 308.18,
+        "peak": 308.18,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 40.54,
+        "p90": 44.75,
+        "peak": 44.75,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.642,
+        "mean_accept_len": 5.494,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.939,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.8,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.698,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.611,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.539,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.487,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.419
+        }
+      }
+    },
+    "c20": {
+      "agg_tok_s": {
+        "median": 334.57,
+        "p90": 370.21,
+        "peak": 370.21,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 42.32,
+        "p90": 46.83,
+        "peak": 46.83,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.63,
+        "mean_accept_len": 5.41,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.929,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.786,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.683,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.603,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.531,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.471,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.407
+        }
+      }
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/02-seqs64.json
+++ b/docs/speed-run-2026-08-31-results/02-seqs64.json
@@ -1,0 +1,303 @@
+{
+  "label": "02-seqs64",
+  "started": "2026-08-31 04:27:25",
+  "url": "http://100.113.138.96:8000",
+  "single": {
+    "count100": {
+      "decode_tok_s": {
+        "median": 98.78,
+        "p90": 100.6,
+        "peak": 100.6,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 87.42,
+        "p90": 90.25,
+        "peak": 90.25,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.21,
+        "p90": 0.31,
+        "peak": 0.31,
+        "n": 3
+      },
+      "completion_tokens": 200,
+      "prompt_tokens": 33,
+      "spec": {
+        "accept_ratio": 0.9136,
+        "mean_accept_len": 7.395,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.975,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.926,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.914,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.815,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.765
+        }
+      }
+    },
+    "code": {
+      "decode_tok_s": {
+        "median": 73.12,
+        "p90": 74.99,
+        "peak": 74.99,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 69.25,
+        "p90": 73.16,
+        "peak": 73.16,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.25,
+        "p90": 0.55,
+        "peak": 0.55,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 58,
+      "spec": {
+        "accept_ratio": 0.6598,
+        "mean_accept_len": 5.619,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.816,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.747,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.653,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.56,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.501,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.408
+        }
+      }
+    },
+    "prose": {
+      "decode_tok_s": {
+        "median": 27.81,
+        "p90": 28.75,
+        "peak": 28.75,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 27.65,
+        "p90": 28.55,
+        "peak": 28.55,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.2,
+        "p90": 0.23,
+        "peak": 0.23,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 51,
+      "spec": {
+        "accept_ratio": 0.1679,
+        "mean_accept_len": 2.175,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.604,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.344,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.144,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.057,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.016,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.008,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.002
+        }
+      }
+    }
+  },
+  "sweep": {
+    "c1": {
+      "agg_tok_s": {
+        "median": 65.88,
+        "p90": 70.04,
+        "peak": 70.04,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 10.67,
+        "p90": 11.34,
+        "peak": 11.34,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6451,
+        "mean_accept_len": 5.516,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.953,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.787,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.697,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.61,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.543,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.504,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.421
+        }
+      }
+    },
+    "c4": {
+      "agg_tok_s": {
+        "median": 111.68,
+        "p90": 112.89,
+        "peak": 112.89,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 25.07,
+        "p90": 25.34,
+        "peak": 25.34,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6519,
+        "mean_accept_len": 5.563,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.942,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.799,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.699,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.623,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.562,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.504,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.435
+        }
+      }
+    },
+    "c8": {
+      "agg_tok_s": {
+        "median": 224.3,
+        "p90": 229.01,
+        "peak": 229.01,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 24.98,
+        "p90": 25.5,
+        "peak": 25.5,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6453,
+        "mean_accept_len": 5.517,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.939,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.801,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.701,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.622,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.546,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.486,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.422
+        }
+      }
+    },
+    "c16": {
+      "agg_tok_s": {
+        "median": 249.29,
+        "p90": 290.44,
+        "peak": 290.44,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 46.19,
+        "p90": 53.81,
+        "peak": 53.81,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6367,
+        "mean_accept_len": 5.457,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.796,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.701,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.609,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.53,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.476,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.411
+        }
+      }
+    },
+    "c24": {
+      "agg_tok_s": {
+        "median": 361.59,
+        "p90": 394.64,
+        "peak": 394.64,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 46.85,
+        "p90": 51.14,
+        "peak": 51.14,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.635,
+        "mean_accept_len": 5.445,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.794,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.694,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.605,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.532,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.478,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.408
+        }
+      }
+    },
+    "c32": {
+      "agg_tok_s": {
+        "median": 430.21,
+        "p90": 445.54,
+        "peak": 445.54,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 52.13,
+        "p90": 53.99,
+        "peak": 53.99,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6361,
+        "mean_accept_len": 5.453,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.934,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.789,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.689,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.607,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.54,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.481,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.413
+        }
+      }
+    },
+    "c48": {
+      "agg_tok_s": {
+        "median": 519.14,
+        "p90": 538.96,
+        "peak": 538.96,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 64.82,
+        "p90": 67.29,
+        "peak": 67.29,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6329,
+        "mean_accept_len": 5.43,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.932,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.786,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.68,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.601,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.535,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.481,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.415
+        }
+      }
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/03-seqs64-localargmax.json
+++ b/docs/speed-run-2026-08-31-results/03-seqs64-localargmax.json
@@ -1,0 +1,249 @@
+{
+  "label": "03-seqs64-localargmax",
+  "started": "2026-08-31 04:58:07",
+  "url": "http://100.113.138.96:8000",
+  "single": {
+    "count100": {
+      "decode_tok_s": {
+        "median": 102.13,
+        "p90": 102.7,
+        "peak": 102.7,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 92.77,
+        "p90": 93.19,
+        "peak": 93.19,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.21,
+        "p90": 0.33,
+        "peak": 0.33,
+        "n": 3
+      },
+      "completion_tokens": 200,
+      "prompt_tokens": 33,
+      "spec": {
+        "accept_ratio": 0.9542,
+        "mean_accept_len": 7.679,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.987,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.987,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.962,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.885,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.859
+        }
+      }
+    },
+    "code": {
+      "decode_tok_s": {
+        "median": 67.35,
+        "p90": 68.14,
+        "peak": 68.14,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 65.97,
+        "p90": 66.48,
+        "peak": 66.48,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.23,
+        "p90": 0.27,
+        "peak": 0.27,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 58,
+      "spec": {
+        "accept_ratio": 0.6403,
+        "mean_accept_len": 5.482,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.94,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.784,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.695,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.617,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.526,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.484,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.435
+        }
+      }
+    },
+    "prose": {
+      "decode_tok_s": {
+        "median": 24.81,
+        "p90": 28.29,
+        "peak": 28.29,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 24.67,
+        "p90": 28.06,
+        "peak": 28.06,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.24,
+        "p90": 0.3,
+        "peak": 0.3,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 51,
+      "spec": {
+        "accept_ratio": 0.1844,
+        "mean_accept_len": 2.291,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.638,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.343,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.161,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.085,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.038,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.016,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.009
+        }
+      }
+    }
+  },
+  "sweep": {
+    "c1": {
+      "agg_tok_s": {
+        "median": 63.11,
+        "p90": 63.43,
+        "peak": 63.43,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 11.09,
+        "p90": 11.15,
+        "peak": 11.15,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6642,
+        "mean_accept_len": 5.649,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.944,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.802,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.718,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.641,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.569,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.52,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.456
+        }
+      }
+    },
+    "c8": {
+      "agg_tok_s": {
+        "median": 184.15,
+        "p90": 215.37,
+        "peak": 215.37,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 31.31,
+        "p90": 36.62,
+        "peak": 36.62,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6374,
+        "mean_accept_len": 5.462,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.937,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.79,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.691,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.605,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.536,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.479,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.424
+        }
+      }
+    },
+    "c16": {
+      "agg_tok_s": {
+        "median": 251.32,
+        "p90": 294.63,
+        "peak": 294.63,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 45.93,
+        "p90": 53.84,
+        "peak": 53.84,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6427,
+        "mean_accept_len": 5.499,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.796,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.698,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.617,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.545,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.492,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.418
+        }
+      }
+    },
+    "c32": {
+      "agg_tok_s": {
+        "median": 373.98,
+        "p90": 421.85,
+        "peak": 421.85,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 60.89,
+        "p90": 68.69,
+        "peak": 68.69,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6352,
+        "mean_accept_len": 5.446,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.934,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.791,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.686,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.605,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.537,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.48,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.413
+        }
+      }
+    },
+    "c48": {
+      "agg_tok_s": {
+        "median": 482.47,
+        "p90": 490.9,
+        "peak": 490.9,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 69.66,
+        "p90": 70.88,
+        "peak": 70.88,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6385,
+        "mean_accept_len": 5.47,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.936,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.795,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.691,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.612,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.541,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.481,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.414
+        }
+      }
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/04-seqs64-piecewise.json
+++ b/docs/speed-run-2026-08-31-results/04-seqs64-piecewise.json
@@ -1,0 +1,249 @@
+{
+  "label": "04-seqs64-piecewise",
+  "started": "2026-08-31 05:25:24",
+  "url": "http://100.113.138.96:8000",
+  "single": {
+    "count100": {
+      "decode_tok_s": {
+        "median": 80.04,
+        "p90": 81.81,
+        "peak": 81.81,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 72.93,
+        "p90": 73.48,
+        "peak": 73.48,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.24,
+        "p90": 0.31,
+        "peak": 0.31,
+        "n": 3
+      },
+      "completion_tokens": 200,
+      "prompt_tokens": 33,
+      "spec": {
+        "accept_ratio": 0.925,
+        "mean_accept_len": 7.475,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.988,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.963,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.938,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.812,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.775
+        }
+      }
+    },
+    "code": {
+      "decode_tok_s": {
+        "median": 58.81,
+        "p90": 59.17,
+        "peak": 59.17,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 57.76,
+        "p90": 57.76,
+        "peak": 57.76,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.3,
+        "p90": 0.31,
+        "peak": 0.31,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 58,
+      "spec": {
+        "accept_ratio": 0.6852,
+        "mean_accept_len": 5.796,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.948,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.824,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.744,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.661,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.598,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.545,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.477
+        }
+      }
+    },
+    "prose": {
+      "decode_tok_s": {
+        "median": 23.98,
+        "p90": 26.25,
+        "peak": 26.25,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 23.78,
+        "p90": 26.0,
+        "peak": 26.0,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.28,
+        "p90": 0.29,
+        "peak": 0.29,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 51,
+      "spec": {
+        "accept_ratio": 0.1935,
+        "mean_accept_len": 2.355,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.631,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.363,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.196,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.089,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.046,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.02,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.01
+        }
+      }
+    }
+  },
+  "sweep": {
+    "c1": {
+      "agg_tok_s": {
+        "median": 53.7,
+        "p90": 54.52,
+        "peak": 54.52,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 13.04,
+        "p90": 13.24,
+        "peak": 13.24,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6406,
+        "mean_accept_len": 5.484,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.934,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.793,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.684,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.609,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.551,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.488,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.426
+        }
+      }
+    },
+    "c8": {
+      "agg_tok_s": {
+        "median": 183.49,
+        "p90": 186.48,
+        "peak": 186.48,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 30.53,
+        "p90": 31.03,
+        "peak": 31.03,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6367,
+        "mean_accept_len": 5.457,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.934,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.79,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.686,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.605,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.539,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.485,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.418
+        }
+      }
+    },
+    "c16": {
+      "agg_tok_s": {
+        "median": 237.37,
+        "p90": 256.09,
+        "peak": 256.09,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 47.48,
+        "p90": 51.22,
+        "peak": 51.22,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6361,
+        "mean_accept_len": 5.453,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.936,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.796,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.688,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.605,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.536,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.48,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.411
+        }
+      }
+    },
+    "c32": {
+      "agg_tok_s": {
+        "median": 395.19,
+        "p90": 396.79,
+        "peak": 396.79,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 56.68,
+        "p90": 56.91,
+        "peak": 56.91,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6452,
+        "mean_accept_len": 5.517,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.94,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.798,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.697,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.62,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.548,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.491,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.424
+        }
+      }
+    },
+    "c48": {
+      "agg_tok_s": {
+        "median": 451.31,
+        "p90": 466.65,
+        "peak": 466.65,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 74.54,
+        "p90": 77.07,
+        "peak": 77.07,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.64,
+        "mean_accept_len": 5.48,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.937,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.795,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.694,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.612,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.543,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.485,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.415
+        }
+      }
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/05-seqs128-batched16k.json
+++ b/docs/speed-run-2026-08-31-results/05-seqs128-batched16k.json
@@ -1,0 +1,266 @@
+{
+  "label": "05-seqs128-batched16k",
+  "started": "2026-08-31 05:52:35",
+  "url": "http://100.113.138.96:8000",
+  "single": {
+    "count100": {
+      "decode_tok_s": {
+        "median": 101.73,
+        "p90": 101.94,
+        "peak": 101.94,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 92.51,
+        "p90": 92.93,
+        "peak": 92.93,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.2,
+        "p90": 0.29,
+        "peak": 0.29,
+        "n": 3
+      },
+      "completion_tokens": 200,
+      "prompt_tokens": 33,
+      "spec": {
+        "accept_ratio": 0.9524,
+        "mean_accept_len": 7.667,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.962,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.859,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.846
+        }
+      }
+    },
+    "code": {
+      "decode_tok_s": {
+        "median": 72.06,
+        "p90": 74.1,
+        "peak": 74.1,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 70.36,
+        "p90": 72.76,
+        "peak": 72.76,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.25,
+        "p90": 0.35,
+        "peak": 0.35,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 58,
+      "spec": {
+        "accept_ratio": 0.6528,
+        "mean_accept_len": 5.57,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.939,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.799,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.712,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.628,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.549,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.507,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.435
+        }
+      }
+    },
+    "prose": {
+      "decode_tok_s": {
+        "median": 29.23,
+        "p90": 30.34,
+        "peak": 30.34,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 29.06,
+        "p90": 30.06,
+        "peak": 30.06,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.24,
+        "p90": 0.24,
+        "peak": 0.24,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 51,
+      "spec": {
+        "accept_ratio": 0.1859,
+        "mean_accept_len": 2.301,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.632,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.341,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.187,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.08,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.035,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.016,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.01
+        }
+      }
+    }
+  },
+  "prefill": {
+    "4096": {
+      "prompt_tokens": 13639,
+      "ttft_s": 10.23,
+      "prefill_tok_s": 1333.3
+    },
+    "16384": {
+      "prompt_tokens": 56196,
+      "ttft_s": 27.359,
+      "prefill_tok_s": 2054.0
+    },
+    "32768": {
+      "prompt_tokens": 113916,
+      "ttft_s": 59.622,
+      "prefill_tok_s": 1910.6
+    }
+  },
+  "sweep": {
+    "c1": {
+      "agg_tok_s": {
+        "median": 69.25,
+        "p90": 73.4,
+        "peak": 73.4,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 10.14,
+        "p90": 10.75,
+        "peak": 10.75,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6471,
+        "mean_accept_len": 5.53,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.937,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.794,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.676,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.605,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.561,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.522,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.435
+        }
+      }
+    },
+    "c8": {
+      "agg_tok_s": {
+        "median": 195.87,
+        "p90": 225.47,
+        "peak": 225.47,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 29.26,
+        "p90": 33.68,
+        "peak": 33.68,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6355,
+        "mean_accept_len": 5.449,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.94,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.794,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.687,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.6,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.534,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.484,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.408
+        }
+      }
+    },
+    "c32": {
+      "agg_tok_s": {
+        "median": 321.9,
+        "p90": 351.21,
+        "peak": 351.21,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 70.17,
+        "p90": 76.55,
+        "peak": 76.55,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6425,
+        "mean_accept_len": 5.498,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.938,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.796,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.691,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.614,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.548,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.49,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.42
+        }
+      }
+    },
+    "c64": {
+      "agg_tok_s": {
+        "median": 433.97,
+        "p90": 443.23,
+        "peak": 443.23,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 103.28,
+        "p90": 105.48,
+        "peak": 105.48,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6368,
+        "mean_accept_len": 5.458,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.935,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.792,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.69,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.608,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.539,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.48,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.414
+        }
+      }
+    },
+    "c96": {
+      "agg_tok_s": {
+        "median": 540.45,
+        "p90": 547.5,
+        "peak": 547.5,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 124.36,
+        "p90": 125.98,
+        "peak": 125.98,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6343,
+        "mean_accept_len": 5.44,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.793,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.687,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.605,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.531,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.478,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.413
+        }
+      }
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/06-seqs64-batched16k-GATE.json
+++ b/docs/speed-run-2026-08-31-results/06-seqs64-batched16k-GATE.json
@@ -1,0 +1,21 @@
+{
+  "label": "06-seqs64-batched16k-GATE",
+  "started": "2026-08-31 06:35:12",
+  "url": "http://100.113.138.96:8000",
+  "longctx": {
+    "c1": {
+      "agg_tok_s": 4.11,
+      "per_stream_tok_s": 38.05,
+      "wall_s": 60.8,
+      "prompt_tokens": 113918,
+      "fails": 0
+    },
+    "c2": {
+      "agg_tok_s": 7.7,
+      "per_stream_tok_s": 18.25,
+      "wall_s": 65.0,
+      "prompt_tokens": 113918,
+      "fails": 0
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/06-seqs64-batched16k.json
+++ b/docs/speed-run-2026-08-31-results/06-seqs64-batched16k.json
@@ -1,0 +1,266 @@
+{
+  "label": "06-seqs64-batched16k",
+  "started": "2026-08-31 06:24:01",
+  "url": "http://100.113.138.96:8000",
+  "single": {
+    "count100": {
+      "decode_tok_s": {
+        "median": 102.81,
+        "p90": 103.64,
+        "peak": 103.64,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 89.82,
+        "p90": 94.19,
+        "peak": 94.19,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.25,
+        "p90": 0.29,
+        "peak": 0.29,
+        "n": 3
+      },
+      "completion_tokens": 200,
+      "prompt_tokens": 33,
+      "spec": {
+        "accept_ratio": 0.956,
+        "mean_accept_len": 7.692,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.974,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.962,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.962,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.91,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.885
+        }
+      }
+    },
+    "code": {
+      "decode_tok_s": {
+        "median": 66.9,
+        "p90": 72.25,
+        "peak": 72.25,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 65.46,
+        "p90": 70.52,
+        "peak": 70.52,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.25,
+        "p90": 0.26,
+        "peak": 0.26,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 58,
+      "spec": {
+        "accept_ratio": 0.6423,
+        "mean_accept_len": 5.496,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.927,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.789,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.695,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.611,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.546,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.501,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.428
+        }
+      }
+    },
+    "prose": {
+      "decode_tok_s": {
+        "median": 27.74,
+        "p90": 28.05,
+        "peak": 28.05,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 27.51,
+        "p90": 27.87,
+        "peak": 27.87,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.24,
+        "p90": 0.24,
+        "peak": 0.24,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 51,
+      "spec": {
+        "accept_ratio": 0.1716,
+        "mean_accept_len": 2.201,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.597,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.338,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.144,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.073,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.033,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.013,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.004
+        }
+      }
+    }
+  },
+  "prefill": {
+    "4096": {
+      "prompt_tokens": 13638,
+      "ttft_s": 8.278,
+      "prefill_tok_s": 1647.5
+    },
+    "16384": {
+      "prompt_tokens": 56197,
+      "ttft_s": 30.072,
+      "prefill_tok_s": 1868.8
+    },
+    "32768": {
+      "prompt_tokens": 113916,
+      "ttft_s": 61.155,
+      "prefill_tok_s": 1862.8
+    }
+  },
+  "sweep": {
+    "c1": {
+      "agg_tok_s": {
+        "median": 69.12,
+        "p90": 71.01,
+        "peak": 71.01,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 10.13,
+        "p90": 10.41,
+        "peak": 10.41,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6499,
+        "mean_accept_len": 5.549,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.937,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.794,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.696,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.613,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.565,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.514,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.431
+        }
+      }
+    },
+    "c8": {
+      "agg_tok_s": {
+        "median": 203.22,
+        "p90": 238.29,
+        "peak": 238.29,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 28.4,
+        "p90": 33.3,
+        "peak": 33.3,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6353,
+        "mean_accept_len": 5.447,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.932,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.789,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.689,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.61,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.532,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.481,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.414
+        }
+      }
+    },
+    "c16": {
+      "agg_tok_s": {
+        "median": 261.6,
+        "p90": 307.21,
+        "peak": 307.21,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 44.15,
+        "p90": 51.85,
+        "peak": 51.85,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6279,
+        "mean_accept_len": 5.395,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.928,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.786,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.676,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.595,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.529,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.474,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.408
+        }
+      }
+    },
+    "c32": {
+      "agg_tok_s": {
+        "median": 389.17,
+        "p90": 436.63,
+        "peak": 436.63,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 58.43,
+        "p90": 65.55,
+        "peak": 65.55,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6406,
+        "mean_accept_len": 5.484,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.934,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.796,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.695,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.611,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.542,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.487,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.42
+        }
+      }
+    },
+    "c48": {
+      "agg_tok_s": {
+        "median": 503.28,
+        "p90": 512.21,
+        "peak": 512.21,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 66.78,
+        "p90": 67.97,
+        "peak": 67.97,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6397,
+        "mean_accept_len": 5.478,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.937,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.793,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.692,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.611,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.544,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.485,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.416
+        }
+      }
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/07-dynamick.json
+++ b/docs/speed-run-2026-08-31-results/07-dynamick.json
@@ -1,0 +1,248 @@
+{
+  "label": "07-dynamick",
+  "started": "2026-08-31 06:56:36",
+  "url": "http://100.113.138.96:8000",
+  "single": {
+    "count100": {
+      "decode_tok_s": {
+        "median": 102.23,
+        "p90": 103.11,
+        "peak": 103.11,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 91.86,
+        "p90": 93.34,
+        "peak": 93.34,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.2,
+        "p90": 0.28,
+        "peak": 0.28,
+        "n": 3
+      },
+      "completion_tokens": 200,
+      "prompt_tokens": 33,
+      "spec": {
+        "accept_ratio": 0.9385,
+        "mean_accept_len": 7.57,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.975,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.949,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.823,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.823
+        }
+      }
+    },
+    "code": {
+      "decode_tok_s": {
+        "median": 75.91,
+        "p90": 78.25,
+        "peak": 78.25,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 74.23,
+        "p90": 74.73,
+        "peak": 74.73,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.22,
+        "p90": 0.43,
+        "peak": 0.43,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 58,
+      "spec": {
+        "accept_ratio": 0.6729,
+        "mean_accept_len": 5.71,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.938,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.824,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.734,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.653,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.591,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.528,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.442
+        }
+      }
+    },
+    "prose": {
+      "decode_tok_s": {
+        "median": 24.65,
+        "p90": 24.9,
+        "peak": 24.9,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 24.53,
+        "p90": 24.78,
+        "peak": 24.78,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.18,
+        "p90": 0.35,
+        "peak": 0.35,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 51,
+      "spec": {
+        "accept_ratio": 0.1755,
+        "mean_accept_len": 2.228,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.633,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.32,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.155,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.073,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.031,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.012,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.005
+        }
+      }
+    }
+  },
+  "sweep": {
+    "c1": {
+      "agg_tok_s": {
+        "median": 69.97,
+        "p90": 71.55,
+        "peak": 71.55,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 10.01,
+        "p90": 10.24,
+        "peak": 10.24,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6445,
+        "mean_accept_len": 5.512,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.783,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.685,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.602,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.551,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.504,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.453
+        }
+      }
+    },
+    "c8": {
+      "agg_tok_s": {
+        "median": 205.32,
+        "p90": 246.15,
+        "peak": 246.15,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 28.4,
+        "p90": 34.04,
+        "peak": 34.04,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6331,
+        "mean_accept_len": 5.432,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.936,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.791,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.685,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.597,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.531,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.478,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.414
+        }
+      }
+    },
+    "c16": {
+      "agg_tok_s": {
+        "median": 267.07,
+        "p90": 317.03,
+        "peak": 317.03,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 43.46,
+        "p90": 51.59,
+        "peak": 51.59,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.7377,
+        "mean_accept_len": 4.695,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.945,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.813,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.71,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.644,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.579,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.003,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.002
+        }
+      }
+    },
+    "c32": {
+      "agg_tok_s": {
+        "median": 389.75,
+        "p90": 395.64,
+        "peak": 395.64,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 57.49,
+        "p90": 58.35,
+        "peak": 58.35,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.7422,
+        "mean_accept_len": 4.713,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.948,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.814,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.717,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.645,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.589,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.001,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.0
+        }
+      }
+    },
+    "c48": {
+      "agg_tok_s": {
+        "median": 500.07,
+        "p90": 526.99,
+        "peak": 526.99,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 67.39,
+        "p90": 71.01,
+        "peak": 71.01,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.8418,
+        "mean_accept_len": 3.531,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.948,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.833,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.745,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.003,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.002,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.0
+        }
+      }
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/08-SHIPPED-confirm.json
+++ b/docs/speed-run-2026-08-31-results/08-SHIPPED-confirm.json
@@ -1,0 +1,212 @@
+{
+  "label": "08-SHIPPED-confirm",
+  "started": "2026-08-31 07:23:45",
+  "url": "http://100.113.138.96:8000",
+  "single": {
+    "count100": {
+      "decode_tok_s": {
+        "median": 101.64,
+        "p90": 103.33,
+        "peak": 103.33,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 86.1,
+        "p90": 93.81,
+        "peak": 93.81,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.21,
+        "p90": 0.56,
+        "peak": 0.56,
+        "n": 3
+      },
+      "completion_tokens": 200,
+      "prompt_tokens": 33,
+      "spec": {
+        "accept_ratio": 0.9542,
+        "mean_accept_len": 7.679,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 1.0,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.987,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.987,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.987,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.962,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.885,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.872
+        }
+      }
+    },
+    "code": {
+      "decode_tok_s": {
+        "median": 72.03,
+        "p90": 76.77,
+        "peak": 76.77,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 70.14,
+        "p90": 73.62,
+        "peak": 73.62,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.28,
+        "p90": 0.4,
+        "peak": 0.4,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 58,
+      "spec": {
+        "accept_ratio": 0.6563,
+        "mean_accept_len": 5.594,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.92,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.804,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.714,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.645,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.573,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.501,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.438
+        }
+      }
+    },
+    "prose": {
+      "decode_tok_s": {
+        "median": 26.92,
+        "p90": 28.77,
+        "peak": 28.77,
+        "n": 3
+      },
+      "e2e_tok_s": {
+        "median": 26.7,
+        "p90": 28.58,
+        "peak": 28.58,
+        "n": 3
+      },
+      "ttft_s": {
+        "median": 0.19,
+        "p90": 0.25,
+        "peak": 0.25,
+        "n": 3
+      },
+      "completion_tokens": 700,
+      "prompt_tokens": 51,
+      "spec": {
+        "accept_ratio": 0.1723,
+        "mean_accept_len": 2.206,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.625,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.318,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.146,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.067,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.028,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.013,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.008
+        }
+      }
+    }
+  },
+  "prefill": {
+    "4096": {
+      "prompt_tokens": 13639,
+      "ttft_s": 18.061,
+      "prefill_tok_s": 755.2
+    },
+    "16384": {
+      "prompt_tokens": 56196,
+      "ttft_s": 27.656,
+      "prefill_tok_s": 2032.0
+    },
+    "32768": {
+      "prompt_tokens": 113917,
+      "ttft_s": 97.13,
+      "prefill_tok_s": 1172.8
+    }
+  },
+  "sweep": {
+    "c1": {
+      "agg_tok_s": {
+        "median": 65.71,
+        "p90": 72.44,
+        "peak": 72.44,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 10.77,
+        "p90": 11.87,
+        "peak": 11.87,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6502,
+        "mean_accept_len": 5.552,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.944,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.79,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.687,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.599,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.556,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.524,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.452
+        }
+      }
+    },
+    "c16": {
+      "agg_tok_s": {
+        "median": 254.41,
+        "p90": 302.3,
+        "peak": 302.3,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 45.64,
+        "p90": 54.23,
+        "peak": 54.23,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6381,
+        "mean_accept_len": 5.467,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.933,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.796,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.691,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.612,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.541,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.482,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.412
+        }
+      }
+    },
+    "c48": {
+      "agg_tok_s": {
+        "median": 469.74,
+        "p90": 526.99,
+        "peak": 526.99,
+        "n": 2
+      },
+      "wall_s": {
+        "median": 72.61,
+        "p90": 81.46,
+        "peak": 81.46,
+        "n": 2
+      },
+      "spec": {
+        "accept_ratio": 0.6433,
+        "mean_accept_len": 5.503,
+        "per_pos": {
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"0\"": 0.94,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"1\"": 0.796,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"2\"": 0.696,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"3\"": 0.615,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"4\"": 0.547,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"5\"": 0.489,
+          "engine=\"0\",model_name=\"glm-5.3-flash\",position=\"6\"": 0.42
+        }
+      }
+    }
+  }
+}

--- a/docs/speed-run-2026-08-31-results/09-SHIPPED-prefill-warm.json
+++ b/docs/speed-run-2026-08-31-results/09-SHIPPED-prefill-warm.json
@@ -1,0 +1,22 @@
+{
+  "label": "09-SHIPPED-prefill-warm",
+  "started": "2026-08-31 07:32:50",
+  "url": "http://100.113.138.96:8000",
+  "prefill": {
+    "4096": {
+      "prompt_tokens": 13639,
+      "ttft_s": 6.52,
+      "prefill_tok_s": 2091.8
+    },
+    "16384": {
+      "prompt_tokens": 56198,
+      "ttft_s": 26.872,
+      "prefill_tok_s": 2091.3
+    },
+    "32768": {
+      "prompt_tokens": 113915,
+      "ttft_s": 54.774,
+      "prefill_tok_s": 2079.7
+    }
+  }
+}

--- a/launch-glm53-tp4-24g.sh
+++ b/launch-glm53-tp4-24g.sh
@@ -69,10 +69,25 @@ docker run --gpus all -d \
     --tensor-parallel-size 4 \
     --gpu-memory-utilization 0.85 \
     --max-model-len 1048576 \
-    --max-num-seqs 6 --block-size 2304 --moe-backend marlin \
-    --max-num-batched-tokens 8192 \
+    `# max-num-seqs 6 -> 64: the old value was the binding constraint on aggregate` \
+    `# throughput, not the fabric. Aggregate was still climbing monotonically when it hit` \
+    `# the cap. 6 -> 64 took best aggregate 183 -> 519 tok/s. Single stream is unaffected.` \
+    `# See docs/SPEED-RUN-2026-08-31.md.` \
+    --max-num-seqs 64 --block-size 2304 --moe-backend marlin \
+    `# 8192 -> 16384: prefill +36-56% (114K prompt: 1194 -> 1863 tok/s, TTFT 95s -> 61s).` \
+    `# Costs ~3% aggregate at C48. Worth it for agentic/long-prompt traffic; set back to` \
+    `# 8192 if you only care about aggregate decode.` \
+    --max-num-batched-tokens 16384 \
     --speculative-config '{"method":"dflash","model":"/models/dflash2-draft","num_speculative_tokens":7}' \
     --kv-cache-dtype fp8_e4m3 --kv-cache-memory 25769803776 \
+    `# DO NOT REMOVE --enforce-eager. This was tested on 2026-08-31, not assumed:` \
+    `# cudagraph_mode PIECEWISE measured -19% single stream and -8..18% aggregate, and` \
+    `# cost 4 extra minutes of startup. 34 of 45 layers are KDA linear-attention` \
+    `# (UNIFORM_SINGLE_TOKEN_DECODE, ineligible for full capture), so PIECEWISE must split` \
+    `# the graph around them and the boundaries cost more than the launch overhead they` \
+    `# remove; spec decode compounds it because the verify batch shape varies with how many` \
+    `# draft positions were accepted. The widely-quoted "+55% from CUDA graphs on SM121"` \
+    `# does not apply to hybrid linear-attention models.` \
     --enforce-eager \
     --tool-call-parser glm47 --enable-auto-tool-choice \
     --reasoning-parser glm45 --chat-template /models/glm-5.3-flash-nvfp4/chat_template_mm.jinja \

--- a/launch-glm53-tp4-24g.sh
+++ b/launch-glm53-tp4-24g.sh
@@ -80,15 +80,18 @@ docker run --gpus all -d \
     --max-num-batched-tokens 16384 \
     --speculative-config '{"method":"dflash","model":"/models/dflash2-draft","num_speculative_tokens":7}' \
     --kv-cache-dtype fp8_e4m3 --kv-cache-memory 25769803776 \
-    `# DO NOT REMOVE --enforce-eager. This was tested on 2026-08-31, not assumed:` \
-    `# cudagraph_mode PIECEWISE measured -19% single stream and -8..18% aggregate, and` \
-    `# cost 4 extra minutes of startup. 34 of 45 layers are KDA linear-attention` \
-    `# (UNIFORM_SINGLE_TOKEN_DECODE, ineligible for full capture), so PIECEWISE must split` \
-    `# the graph around them and the boundaries cost more than the launch overhead they` \
-    `# remove; spec decode compounds it because the verify batch shape varies with how many` \
-    `# draft positions were accepted. The widely-quoted "+55% from CUDA graphs on SM121"` \
-    `# does not apply to hybrid linear-attention models.` \
-    --enforce-eager \
+    `# CUDA graphs: use FULL_AND_PIECEWISE on this (fp8 KV + marlin) lane.` \
+    `# CORRECTION 2026-09-02 -- an earlier revision of this file said "DO NOT REMOVE` \
+    `# --enforce-eager" on the strength of a -19% measurement. That measurement was real` \
+    `# but tested the WRONG MODE: plain PIECEWISE, which forces piecewise graphs onto the` \
+    `# decode path. FULL_AND_PIECEWISE uses FULL for uniform decode batches and piecewise` \
+    `# only for mixed/prefill, and measures FASTER than eager on all three prompt types:` \
+    `#   count-to-100 101.6 -> 105.6   code 72.0 -> 77.3   prose 26.9 -> 31.5` \
+    `#   best aggregate 503.3 -> 530.0 tok/s` \
+    `# --enforce-eager is a property of the NVFP4-KV/b12x lane, NOT of this model: the b12x` \
+    `# kernels require it, marlin does not. Keep eager ONLY on the b12x lane, and on the` \
+    `# topkfix image (docs/TOPK-OVERSUSCRIPTION-FIX.md), which deadlocks under graphs.` \
+    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}' \
     --tool-call-parser glm47 --enable-auto-tool-choice \
     --reasoning-parser glm45 --chat-template /models/glm-5.3-flash-nvfp4/chat_template_mm.jinja \
     --default-chat-template-kwargs '{"enable_thinking": false}' \

--- a/probes/bench_glm53_tp4.py
+++ b/probes/bench_glm53_tp4.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""bench_glm53_tp4.py — config-comparison bench for GLM-5.3-Flash on the 4-Spark TP4 fleet.
+
+Why not probes/bench_c1c6.py: that harness runs temperature=1.0 (content variance is
+acceptance variance on a spec-decode engine), reports means not medians, and is
+non-streaming so it cannot separate prefill from decode at all. It also has no
+count-to-100 prompt, which is our PEAK number.
+
+This one:
+  * fixed prompt set, temperature 0 -> the same tokens every run, so a config delta
+    is a config delta and not a content delta
+  * streaming, so TTFT / prefill tok/s / decode tok/s / e2e tok/s split out
+  * MEDIAN + P90 + peak across repeats (Tony's rule), not pooled means
+  * C1..C6 aggregate sweep
+  * long-context arm (32K prompt, 1 vs 2 concurrent) -- the regime issue #14 says
+    short-prompt sweeps structurally cannot see
+  * spec-decode acceptance scraped from /metrics as BOTH accepted/drafted ratio and
+    mean accepted length (1 + accepted/drafts), plus per-position when exposed
+
+Usage:
+  python3 bench_glm53_tp4.py --label baseline-eager-k7 --suite all
+  python3 bench_glm53_tp4.py --label nccl-tree-ll --suite single,sweep
+Results append to results/<label>.json and print a table.
+"""
+import argparse, json, os, statistics, threading, time, urllib.request, urllib.error
+
+URL = "http://100.113.138.96:8000"
+MODEL = "glm-5.3-flash"
+
+# ---- fixed prompt set -------------------------------------------------------
+# count100 is the PEAK probe: maximally predictable output -> highest draft
+# acceptance -> the ceiling this engine can hit. code/prose bracket real traffic.
+PROMPTS = {
+    "count100": ("Count from 1 to 100. Output only the numbers, one per line, nothing else.", 400),
+    "code":     ("Write a complete Python implementation of an LRU cache with get and put in "
+                 "O(1), using a dict plus a doubly linked list. Include the class, full method "
+                 "bodies, and a short docstring for each method.", 700),
+    "prose":    ("Explain, in flowing prose with no code, no lists and no headings, how a "
+                 "modern CPU's branch predictor works and why mispredictions are expensive on "
+                 "a deeply pipelined machine.", 700),
+}
+
+
+def post_stream(prompt, max_tokens, temperature=0.0, timeout=900):
+    """One streaming request -> timing split. Returns dict or {'ok': False}."""
+    body = {
+        "model": MODEL,
+        "messages": [{"role": "user", "content": prompt}],
+        "max_tokens": max_tokens,
+        "temperature": temperature,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    req = urllib.request.Request(
+        URL + "/v1/chat/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    t0 = time.perf_counter()
+    ttft = None
+    completion = prompt_toks = None
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            for raw in r:
+                line = raw.decode("utf-8", "replace").strip()
+                if not line.startswith("data: ") or line == "data: [DONE]":
+                    continue
+                ev = json.loads(line[6:])
+                ch = ev.get("choices") or []
+                if ch and ttft is None:
+                    d = ch[0].get("delta") or {}
+                    if d.get("content") or d.get("reasoning_content"):
+                        ttft = time.perf_counter()
+                u = ev.get("usage")
+                if u:
+                    completion = u.get("completion_tokens")
+                    prompt_toks = u.get("prompt_tokens")
+        t1 = time.perf_counter()
+    except Exception as e:
+        return {"ok": False, "err": str(e)[:120]}
+    if not completion:
+        return {"ok": False, "err": "no usage in stream"}
+    ttft = ttft or t1
+    decode_s = max(t1 - ttft, 1e-9)
+    return {
+        "ok": True,
+        "ttft_s": ttft - t0,
+        "total_s": t1 - t0,
+        "prompt_tokens": prompt_toks,
+        "completion_tokens": completion,
+        # prefill rate: prompt tokens digested per second before first token
+        "prefill_tok_s": (prompt_toks / (ttft - t0)) if prompt_toks and (ttft - t0) > 0 else None,
+        "decode_tok_s": (completion - 1) / decode_s,
+        "e2e_tok_s": completion / (t1 - t0),
+    }
+
+
+# ---- spec-decode metrics ----------------------------------------------------
+def spec_metrics():
+    """Scrape vLLM spec-decode counters. Returns dict of name -> float."""
+    out = {}
+    try:
+        txt = urllib.request.urlopen(URL + "/metrics", timeout=15).read().decode()
+    except Exception:
+        return out
+    for line in txt.splitlines():
+        if line.startswith("#") or "spec_decode" not in line:
+            continue
+        parts = line.rsplit(" ", 1)
+        if len(parts) != 2:
+            continue
+        try:
+            out[parts[0]] = float(parts[1])
+        except ValueError:
+            pass
+    return out
+
+
+def spec_delta(before, after):
+    """accepted/drafted ratio + mean accepted length + per-position acceptance."""
+    def g(d, key):
+        for k, v in d.items():
+            if k.startswith(key):
+                return v
+        return None
+
+    dd = (g(after, "vllm:spec_decode_num_draft_tokens_total") or 0) - \
+         (g(before, "vllm:spec_decode_num_draft_tokens_total") or 0)
+    da = (g(after, "vllm:spec_decode_num_accepted_tokens_total") or 0) - \
+         (g(before, "vllm:spec_decode_num_accepted_tokens_total") or 0)
+    dn = (g(after, "vllm:spec_decode_num_drafts_total") or 0) - \
+         (g(before, "vllm:spec_decode_num_drafts_total") or 0)
+    res = {}
+    if dd > 0:
+        res["accept_ratio"] = round(da / dd, 4)
+    if dn > 0:
+        # mean accepted length per step, counting the always-free bonus token
+        res["mean_accept_len"] = round(1 + da / dn, 3)
+    # per-position acceptance, when the build exposes the histogram
+    pos = {}
+    for k, v in after.items():
+        if "accepted_tokens_per_pos" in k:
+            dv = v - before.get(k, 0.0)
+            if dv:
+                pos[k.split("{")[-1].rstrip("}")] = dv
+    if pos and dn > 0:
+        res["per_pos"] = {p: round(c / dn, 3) for p, c in sorted(pos.items())}
+    return res
+
+
+def stats(vals):
+    vals = [v for v in vals if v is not None]
+    if not vals:
+        return {}
+    s = sorted(vals)
+    return {
+        "median": round(statistics.median(s), 2),
+        "p90": round(s[min(len(s) - 1, int(0.9 * len(s)))], 2),
+        "peak": round(max(s), 2),
+        "n": len(s),
+    }
+
+
+# ---- suites -----------------------------------------------------------------
+def suite_single(reps):
+    """Fixed prompts, single stream, repeated. The headline + PEAK numbers."""
+    res = {}
+    for name, (prompt, mt) in PROMPTS.items():
+        before = spec_metrics()
+        runs = []
+        for _ in range(reps):
+            r = post_stream(prompt, mt)
+            if r.get("ok"):
+                runs.append(r)
+        after = spec_metrics()
+        if not runs:
+            res[name] = {"error": "all runs failed"}
+            continue
+        res[name] = {
+            "decode_tok_s": stats([r["decode_tok_s"] for r in runs]),
+            "e2e_tok_s": stats([r["e2e_tok_s"] for r in runs]),
+            "ttft_s": stats([r["ttft_s"] for r in runs]),
+            "completion_tokens": runs[0]["completion_tokens"],
+            "prompt_tokens": runs[0]["prompt_tokens"],
+            "spec": spec_delta(before, after),
+        }
+        print(f"  {name:9s} decode med={res[name]['decode_tok_s'].get('median')} "
+              f"peak={res[name]['decode_tok_s'].get('peak')} "
+              f"ttft={res[name]['ttft_s'].get('median')}s "
+              f"spec={res[name]['spec']}", flush=True)
+    return res
+
+
+def suite_prefill(sizes=(4096, 16384, 32768)):
+    """Prefill throughput vs prompt length. Unique filler defeats any prefix reuse."""
+    res = {}
+    for n in sizes:
+        # ~1 token per word for this filler; salt keeps each run distinct
+        filler = " ".join(f"w{i}" for i in range(n))
+        prompt = f"[{time.time()}] Here is a corpus:\n{filler}\n\nReply with exactly: DONE"
+        r = post_stream(prompt, 16)
+        if r.get("ok"):
+            res[f"{n}"] = {
+                "prompt_tokens": r["prompt_tokens"],
+                "ttft_s": round(r["ttft_s"], 3),
+                "prefill_tok_s": round(r["prefill_tok_s"], 1) if r["prefill_tok_s"] else None,
+            }
+            print(f"  prefill~{n:6d} tokens={r['prompt_tokens']} ttft={r['ttft_s']:.2f}s "
+                  f"rate={r['prefill_tok_s']:.0f} tok/s", flush=True)
+        else:
+            res[f"{n}"] = {"error": r.get("err")}
+            print(f"  prefill~{n:6d} FAILED {r.get('err')}", flush=True)
+    return res
+
+
+def _wave(prompt, mt, c, out):
+    ths = []
+    for i in range(c):
+        def go(i=i):
+            out[i] = post_stream(f"[w{i}] " + prompt, mt)
+        t = threading.Thread(target=go)
+        ths.append(t)
+    t0 = time.perf_counter()
+    [t.start() for t in ths]
+    [t.join() for t in ths]
+    return time.perf_counter() - t0
+
+
+def suite_sweep(levels, rounds):
+    """C1..CN aggregate throughput. Aggregate = total output tokens / wall."""
+    res = {}
+    prompt, mt = PROMPTS["code"]
+    for c in levels:
+        before = spec_metrics()
+        aggs, walls = [], []
+        for _ in range(rounds):
+            out = {}
+            wall = _wave(prompt, mt, c, out)
+            ok = [v for v in out.values() if v and v.get("ok")]
+            toks = sum(v["completion_tokens"] for v in ok)
+            if wall > 0 and ok:
+                aggs.append(toks / wall)
+                walls.append(wall)
+        after = spec_metrics()
+        res[f"c{c}"] = {
+            "agg_tok_s": stats(aggs),
+            "wall_s": stats(walls),
+            "spec": spec_delta(before, after),
+        }
+        print(f"  C{c} agg med={res[f'c{c}']['agg_tok_s'].get('median')} "
+              f"peak={res[f'c{c}']['agg_tok_s'].get('peak')} "
+              f"wall={res[f'c{c}']['wall_s'].get('median')}s", flush=True)
+    return res
+
+
+def suite_longctx(ctx_tokens=32768, levels=(1, 2)):
+    """The regime issue #14 says short-prompt sweeps cannot see: long prompts,
+    2 sequences in decode at once. Reported collapse: ~4 tok/s aggregate."""
+    res = {}
+    filler = " ".join(f"tok{i}" for i in range(ctx_tokens))
+    prompt = (f"Below is a log corpus.\n{filler}\n\n"
+              "Summarize what kind of data this is in about 150 words.")
+    for c in levels:
+        out = {}
+        wall = _wave(prompt, 250, c, out)
+        ok = [v for v in out.values() if v and v.get("ok")]
+        toks = sum(v["completion_tokens"] for v in ok)
+        res[f"c{c}"] = {
+            "agg_tok_s": round(toks / wall, 2) if wall and ok else None,
+            "per_stream_tok_s": round(
+                sum(v["decode_tok_s"] for v in ok) / len(ok), 2) if ok else None,
+            "wall_s": round(wall, 1),
+            "prompt_tokens": ok[0]["prompt_tokens"] if ok else None,
+            "fails": c - len(ok),
+        }
+        print(f"  longctx C{c} agg={res[f'c{c}']['agg_tok_s']} "
+              f"per_stream={res[f'c{c}']['per_stream_tok_s']} "
+              f"prompt_tokens={res[f'c{c}']['prompt_tokens']} "
+              f"fails={res[f'c{c}']['fails']}", flush=True)
+    return res
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--label", required=True, help="config name under test")
+    ap.add_argument("--suite", default="single,sweep",
+                    help="comma list: single,prefill,sweep,longctx,all")
+    ap.add_argument("--reps", type=int, default=3)
+    ap.add_argument("--rounds", type=int, default=2)
+    ap.add_argument("--levels", default="1,2,3,4,5,6")
+    ap.add_argument("--outdir", default=os.path.join(os.path.dirname(__file__), "results"))
+    a = ap.parse_args()
+
+    suites = {s.strip() for s in a.suite.split(",")}
+    if "all" in suites:
+        suites = {"single", "prefill", "sweep", "longctx"}
+    os.makedirs(a.outdir, exist_ok=True)
+
+    print(f"== {a.label} ==", flush=True)
+    print("  warming up...", flush=True)
+    post_stream("hello", 8)
+
+    out = {"label": a.label, "started": time.strftime("%Y-%m-%d %H:%M:%S"), "url": URL}
+    if "single" in suites:
+        print(" [single]", flush=True); out["single"] = suite_single(a.reps)
+    if "prefill" in suites:
+        print(" [prefill]", flush=True); out["prefill"] = suite_prefill()
+    if "sweep" in suites:
+        print(" [sweep]", flush=True)
+        out["sweep"] = suite_sweep([int(x) for x in a.levels.split(",")], a.rounds)
+    if "longctx" in suites:
+        print(" [longctx]", flush=True); out["longctx"] = suite_longctx()
+
+    path = os.path.join(a.outdir, f"{a.label}.json")
+    with open(path, "w") as f:
+        json.dump(out, f, indent=2)
+    print(f"  -> {path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/probes/compare_runs.py
+++ b/probes/compare_runs.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""compare.py — table every results/*.json against the baseline.
+
+Usage: python3 compare.py [--baseline 00-baseline-eager-k7-seqs6] [--md]
+"""
+import argparse, glob, json, os
+
+def pct(new, base):
+    if base in (None, 0) or new is None:
+        return ""
+    d = (new - base) / base * 100
+    return f"{d:+.1f}%"
+
+def get(d, *path, default=None):
+    cur = d
+    for p in path:
+        if not isinstance(cur, dict) or p not in cur:
+            return default
+        cur = cur[p]
+    return cur
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--baseline", default="00-baseline-eager-k7-seqs6")
+    ap.add_argument("--dir", default=os.path.join(os.path.dirname(__file__), "results"))
+    ap.add_argument("--md", action="store_true", help="emit markdown tables")
+    a = ap.parse_args()
+
+    runs = {}
+    for f in sorted(glob.glob(os.path.join(a.dir, "*.json"))):
+        runs[os.path.basename(f)[:-5]] = json.load(open(f))
+    if not runs:
+        print("no results yet"); return
+    base = runs.get(a.baseline)
+
+    sep = "|" if a.md else " "
+    def row(cells, widths):
+        if a.md:
+            return "| " + " | ".join(str(c) for c in cells) + " |"
+        return "  ".join(str(c).ljust(w) for c, w in zip(cells, widths))
+
+    # ---- single-stream decode (the headline + PEAK) ----
+    print("\n### Single-stream decode, tok/s (median, temp 0)\n")
+    hdr = ["config", "count100 PEAK", "code", "prose", "accept(code)", "accept_len(code)"]
+    w = [34, 15, 15, 15, 13, 16]
+    print(row(hdr, w))
+    if a.md: print("|" + "|".join("---" for _ in hdr) + "|")
+    for name, r in runs.items():
+        cells = [name]
+        for p in ("count100", "code", "prose"):
+            v = get(r, "single", p, "decode_tok_s", "median")
+            b = get(base, "single", p, "decode_tok_s", "median") if base else None
+            cells.append(f"{v}" + (f" ({pct(v,b)})" if base and name != a.baseline and v else ""))
+        cells.append(get(r, "single", "code", "spec", "accept_ratio", default="-"))
+        cells.append(get(r, "single", "code", "spec", "mean_accept_len", default="-"))
+        print(row(cells, w))
+
+    # ---- aggregate sweep ----
+    print("\n### Aggregate throughput by concurrency, tok/s (median)\n")
+    levels = sorted({k for r in runs.values() for k in get(r, "sweep", default={})},
+                    key=lambda s: int(s[1:]))
+    hdr = ["config"] + levels + ["best"]
+    w = [34] + [11] * len(levels) + [11]
+    print(row(hdr, w))
+    if a.md: print("|" + "|".join("---" for _ in hdr) + "|")
+    for name, r in runs.items():
+        vals, cells = [], [name]
+        for lv in levels:
+            v = get(r, "sweep", lv, "agg_tok_s", "median")
+            b = get(base, "sweep", lv, "agg_tok_s", "median") if base else None
+            vals.append(v)
+            cells.append(f"{v}" + (f" ({pct(v,b)})" if base and name != a.baseline and v else "")
+                         if v is not None else "-")
+        good = [v for v in vals if v is not None]
+        bb = [get(base, "sweep", lv, "agg_tok_s", "median") for lv in levels] if base else []
+        bb = [v for v in bb if v is not None]
+        cells.append(f"{max(good)}" + (f" ({pct(max(good), max(bb))})"
+                     if bb and name != a.baseline else "") if good else "-")
+        print(row(cells, w))
+
+    # ---- prefill ----
+    print("\n### Prefill, tok/s\n")
+    sizes = sorted({k for r in runs.values() for k in get(r, "prefill", default={})}, key=int)
+    hdr = ["config"] + [f"~{s}w" for s in sizes]
+    w = [34] + [16] * len(sizes)
+    print(row(hdr, w))
+    if a.md: print("|" + "|".join("---" for _ in hdr) + "|")
+    for name, r in runs.items():
+        cells = [name]
+        for s in sizes:
+            v = get(r, "prefill", s, "prefill_tok_s")
+            b = get(base, "prefill", s, "prefill_tok_s") if base else None
+            cells.append(f"{v}" + (f" ({pct(v,b)})" if base and name != a.baseline and v else "")
+                         if v is not None else "-")
+        print(row(cells, w))
+
+    # ---- long context ----
+    print("\n### Long context (~114K prompt), per-stream decode tok/s\n")
+    hdr = ["config", "C1 per-stream", "C2 per-stream", "C1 wall", "C2 wall"]
+    w = [34, 15, 15, 10, 10]
+    print(row(hdr, w))
+    if a.md: print("|" + "|".join("---" for _ in hdr) + "|")
+    for name, r in runs.items():
+        if not get(r, "longctx"): continue
+        print(row([name,
+                   get(r, "longctx", "c1", "per_stream_tok_s", default="-"),
+                   get(r, "longctx", "c2", "per_stream_tok_s", default="-"),
+                   get(r, "longctx", "c1", "wall_s", default="-"),
+                   get(r, "longctx", "c2", "wall_s", default="-")], w))
+    print()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Overnight tuning pass on the shipping TP4 recipe. Every number is **temperature 0**, fixed prompts, median of repeats, measured on the production 4-Spark fleet with a new harness.

## Result: two flags

```diff
- --max-num-seqs 6
+ --max-num-seqs 64
- --max-num-batched-tokens 8192
+ --max-num-batched-tokens 16384
```

| metric | baseline | shipped | change |
|---|---|---|---|
| **aggregate throughput (best)** | 183.1 tok/s @C6 | **503.3 @C48** | **+175%** |
| **prefill @114K prompt** | 1,194 tok/s | **1,863** | **+56%** |
| **TTFT @114K prompt** | 95.4 s | **61.2 s** | **−36%** |
| **PEAK decode (count-to-100)** | 102.15 | **102.81** | +0.6% |
| decode, code | 70.46 | 66.90 | −5.1% |
| decode, dense prose | 26.37 | 27.74 | +5.2% |

Gate-passed at 113,918-token prompts, C1 and C2, zero failures.

`--max-num-seqs 6` was the binding constraint on aggregate, not the fabric — the baseline curve was still climbing monotonically when it hit the cap (C1 56.4 → C6 183.1). Single-stream decode barely moves, which is the expected result: decode is bandwidth-bound per node and TP4 is already at the useful limit. **The headroom was in concurrency and prefill.**

## Two widely-recommended changes that made things worse

Both were tested rather than assumed. Both lost.

| tried | published expectation | measured here |
|---|---|---|
| `cudagraph_mode: PIECEWISE` | +10% to +55% | **−19% single stream, −8..18% aggregate** |
| `use_local_argmax_reduction: true` | +30.6% @tp4/c32 (vLLM PR #39419) | **−13% @C32** |

**`--enforce-eager` is load-bearing and now documented as such in the launcher.** It's widely called unsourced folklore — including in #2 of this repo, which recommends `FULL_DECODE_ONLY`. But 34 of 45 layers are KDA linear-attention, which vLLM classifies `UNIFORM_SINGLE_TOKEN_DECODE` and cannot full-capture, so `FULL` is auto-downgraded and PIECEWISE must split the graph around them. On this model the boundaries cost more than the launch overhead they remove. Acceptance actually *improved* under PIECEWISE (code accept ratio 0.660 → 0.685), so the drafter was fine — the entire loss is per-step cost. Speculative decoding compounds it, since the verify batch shape varies with how many draft positions were accepted.

The `+55% from CUDA graphs on SM121` figure that circulates for this hardware was measured on non-hybrid models and does not transfer.

`use_local_argmax_reduction` is MRv2-only (`VLLM_USE_V2_MODEL_RUNNER=1`), which we don't run. Not pursued further on purpose: MRv2 falls back to V1 with only a `warning_once`, and on V1 a DFlash2 checkpoint silently drafts as DFlash1 — a silent correctness downgrade for an uncertain speed gain.

## Also in here

**`probes/bench_glm53_tp4.py`** — the existing `bench_c1c6.py` can't produce comparable config deltas: it runs temperature 1.0 (content variance *is* acceptance variance on a spec-decode engine), reports pooled means rather than medians, is non-streaming so it cannot separate prefill from decode, and has no count-to-100 PEAK probe. The new harness fixes all four and scrapes per-position acceptance from `/metrics`.

**Per-experiment `VLLM_CACHE_ROOT`.** vLLM [#53366](https://github.com/vllm-project/vllm/issues/53366): `SpeculativeConfig.compute_hash()` omits `num_speculative_tokens`, so any k sweep in a shared cache dir can silently serve an Inductor artifact compiled for a different k. Worth knowing before trusting any k result, including #12 on the sibling repo.

## Two bugs found that aren't about speed

- **Prefix caching never hits.** Identical 495-token prompt twice: `queries +495 / hits +0` both times. Confirms issue #13 on the sibling repo, at TP4 as well as TP2. Mechanism is upstream [vLLM #54360](https://github.com/vllm-project/vllm/issues/54360) — any speculative method on a hybrid-GDN model silently zeroes the hit path. So it's spec-decode × hybrid attention, **not** SM121. Consequence: the gate advice about varying prompts to defeat the prefix cache is currently moot.
- **Verifying image *IDs* across ranks produces false alarms.** All four ranks here report different image IDs (two registries, two build windows) while every `.py` under `vllm/` is byte-identical and all four run the same vLLM hash — only `.pyc` caches differ. Hard-won rule #3 should hash the `.py` surface instead; the one-liner is in the doc.

## Best remaining lead (not attempted)

Dynamic k via `num_speculative_tokens_per_batch_size`. Per-position acceptance on prose is `0.614 / 0.332 / 0.152 / 0.076 / 0.031 / 0.011 / 0.002` — positions 4–6 are nearly pure waste on unpredictable content — while on code the same positions return `0.58 / 0.51 / 0.46` and clearly earn their keep. No single static k serves both. Ran out of reload cycles.

Full method, per-experiment tables, and raw JSON in [`docs/SPEED-RUN-2026-08-31.md`](docs/SPEED-RUN-2026-08-31.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
