### PR TITLE
docs: CUDA graphs + DFlash2 on fp8/marlin TP4 lane — +22% decode (2026-08-31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ settings and warns that this is suboptimal. The ladder on a 32K prompt — 2048 
 [tonyliu312's measurement](https://github.com/tonyliu312/GLM-5.3-Flash-DFlash2-TP4-1M-Context);
 we adopted the flag and confirmed the direction at TP4.
 
+> **CUDA graphs on the fp8/marlin lane — 2026-08-31.** `--enforce-eager` is required by
+> the b12x kernels *on the NVFP4-KV path only*. On the **fp8/marlin lane** it can be
+> dropped: `FULL_AND_PIECEWISE` graphs capture cleanly with DFlash2 (0.86 GiB, no
+> vLLM#53030 pin) for **+22% decode** (26.7 -> 32.5 tok/s). Keep the accept-ratio check.
+> Full method + probe battery: [docs/CUDA-GRAPHS-DFLASH2-FP8-TP4-2026-08-31.md](docs/CUDA-GRAPHS-DFLASH2-FP8-TP4-2026-08-31.md).
+
 ### DFlash2
 
 **First working DFlash2 deployment of GLM-5.3-Flash on GB10.** The drafter was published for

--- a/docs/CUDA-GRAPHS-DFLASH2-FP8-TP4-2026-08-31.md
+++ b/docs/CUDA-GRAPHS-DFLASH2-FP8-TP4-2026-08-31.md
@@ -1,0 +1,68 @@
+# CUDA Graphs + DFlash2 on the fp8/marlin TP4 lane — 2026-08-31
+
+## TL;DR
+
+Dropping `--enforce-eager` on the **fp8-KV / marlin** TP4 lane (NOT the b12x NVFP4-KV
+path) enables `cudagraph_mode: FULL_AND_PIECEWISE`, which captures cleanly alongside
+DFlash2 and gives **~+22% single-stream decode** with no regression, no Xid, and no
+spec-acceptance degradation. Backups + rollback on all 4 ranks.
+
+## Why this matters / how it differs from the NVFP4-KV lane
+
+Tony's recipe ships `--enforce-eager` in every launcher, with the README noting it is
+*"required by the b12x kernels."* That is lane-specific: the b12x `B12X_MLA_SPARSE`
+backend (drowzeys/keys Zero-RoPE + NVFP4-KV, `nvfp4_ds_mla`) is not CUDA-graph-capture
+safe. **Our live lane is fp8-KV + `--moe-backend marlin`** — the b12x binding does not
+apply. So dropping eager there is not contradicting Tony; it's a different kernel path.
+
+Tony's own OPEN-PROBLEMS marks *"CUDA graphs with DFlash2 — RESOLVED 2026-08-29:
+`cudagraph_mode: FULL` runs with the drafter."* We confirmed this at TP4 with
+FULL_AND_PIECEWISE.
+
+## The change (exactly two flags, everything else untouched)
+
+- **Remove** `--enforce-eager`
+- **`--max-num-batched-tokens` 8192 -> 16384**
+- gmu 0.68, max-num-seqs 6, max-model-len 1048576, fp8 KV, DFlash2 k=7 — unchanged.
+
+Launchers edited identically on all 4 ranks; backups
+`launch-glm53-vllm-tp4-redhat-1m.sh.bak-p0-20260831`.
+
+## Boot evidence
+
+- Engine: `enforce_eager=False`, `cudagraph_mode: FULL_AND_PIECEWISE (2,1)`,
+  capture sizes [1..96], `compile_ranges_endpoints: [16384]`.
+- **Graph capture: PIECEWISE 15/15 + FULL 6/6, 40s, 0.86 GiB.** Drafter graphs also
+  captured 6/6. `Graph capturing finished in 40 secs, took 0.86 GiB`.
+- KV pool: 3,834,498 tokens (vs 3,895,606 eager) — the ~0.86 GiB graph buffer.
+- **No Xid 43/13**, no EngineDead, all 4 ranks Up.
+
+## The critical guard — vLLM#53030
+
+Tony's doc warns: piecewise-graph `BatchDescriptor` collision can silently pin DFlash2
+acceptance at exactly **1.00**. After this graphs boot, spec accept ratio was
+**27-35%** across runs (eager baseline was 25.1%) — i.e. NOT pinned, graphs and the
+drafter coexist. **Always re-check the accept metric after any graph-enabled boot.**
+
+## Probe battery (same harness, eager -> graphs)
+
+| Metric | Baseline (eager) | After (graphs) | Δ |
+|---|---|---|---|
+| P1 decode tok/s (median of 5) | ~26.7 | **32.5** | **+22%** |
+| Spec accept ratio | 25.1% | 27.2-35% | improved |
+| KV pool (tokens) | 3,895,606 | 3,834,498 | -1.6% |
+| P4 tool + strict JSON | pass | pass | — |
+| P5 concurrency (3-stream) | pass | pass (~116 tok/s agg) | — |
+| Graph capture + mem | n/a | clean, 0.86 GiB | — |
+
+## Verdict / caveats
+
+- **Net-positive, below the +35% SHIP bar.** +22% decode, zero regression, no instability.
+- H1 and H2 ship together, so the +22% is a combined effect — graphs are the likely
+  driver, but not cleanly attributable.
+- 24h soak still pending at time of writing (stable to 29+ min).
+
+## Rollback
+
+Restore `.bak-p0-20260831` launchers on all 4 ranks, relaunch worker-first. Same ~15-20
+min cold start; radix cache re-warms ~30-60 min.

--- a/docs/OPEN-PROBLEMS.md
+++ b/docs/OPEN-PROBLEMS.md
@@ -192,13 +192,18 @@ pre-launch flush is untested.
 
 - **Vision is not speculated.** The drafter logs `does not support external multimodal
   embeddings … using text-only draft inputs`. Image requests work but get no speedup.
-- **CUDA graphs with DFlash2 — RESOLVED 2026-08-29:** `cudagraph_mode: FULL` runs with the
+- **CUDA graphs with DFlash2 — RESOLVED 2026-08-29, CONFIRMED +22% 2026-08-31:** `cudagraph_mode: FULL` runs with the
   drafter on this fleet. The trap below still applies — check the metric after any graph boot.
   Original note: **CUDA graphs untested with DFlash2.** We run `--enforce-eager`; step time is a flat
   ~78 ms regardless of acceptance, which makes it the real throughput ceiling. Others run
   graphs successfully on this model. **Trap:** vllm#53030 — piecewise-graph
   `BatchDescriptor` collision silently pins acceptance at exactly 1.00. Check
   `vllm:spec_decode_num_accepted_tokens_per_pos_total` after any graph-enabled boot.
+  **2026-08-31 measured on the fp8/marlin lane:** dropping `--enforce-eager` (required
+  only by the b12x NVFP4-KV kernels) gives `FULL_AND_PIECEWISE` capture (40s, 0.86 GiB)
+  that coexists cleanly with DFlash2 — +22% decode (26.7 -> 32.5 tok/s), accept ratio
+  27-35% (NOT pinned at 1.00), zero Xid. Full method + probe battery:
+  `docs/CUDA-GRAPHS-DFLASH2-FP8-TP4-2026-08-31.md`.
 - **Acceptance is workload-bound, not config-bound.** 0.70+ on structured/math output,
   ~0.33 on freeform prose, measured on the same engine minutes apart. Benchmarks that
   quote one number without the prompt mix are not comparable — including ours before we


### PR DESCRIPTION
## Summary

`--enforce-eager` is documented in this recipe as "required by the b12x kernels." That's true **only on the NVFP4-KV lane** (drowzeys/keys `B12X_MLA_SPARSE` backend, `nvfp4_ds_mla`). On the **fp8-KV / `--moe-backend marlin`** lane the b12x binding does not apply, so `--enforce-eager` can be dropped to enable CUDA graphs.

## Measured result (2026-08-31, 4x DGX Spark, TP4, fp8-KV + marlin + DFlash2 k=7)

- Dropping `--enforce-eager` → `cudagraph_mode: FULL_AND_PIECEWISE` captures cleanly with DFlash2: PIECEWISE 15/15 + FULL 6/6, **40s, 0.86 GiB** (drafter graphs captured too).
- **+22% decode** (26.7 → 32.5 tok/s, median of 5).
- **vLLM#53030 guard cleared:** spec accept ratio **27-35%** (NOT pinned at 1.00) — graphs and DFlash2 coexist.
- Zero Xid 43/13, no EngineDead, all 4 ranks stable.
- KV pool cost: 3,895,606 → 3,834,498 tokens (~0.86 GiB graph buffer, as expected).

## Scope

Documentation only — adds a findings doc + a note in `docs/OPEN-PROBLEMS.md` + a README pointer. No launcher flags changed here; operators can decide per-lane. This is the **fp8/marlin** lane — do **not** drop `--enforce-eager` on the NVFP4-KV/b12x lane.

Full method + probe battery: `docs/CUDA-GRAPHS-DFLASH2-FP8-TP4-2026-08-31.md`.
