### PR TITLE
Look up the GID index at launch, plus field notes from a 100G switched fabric

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Corruption first flagged by [@ajclark](https://github.com/ajclark) (issue #10). 
 
 ---
 
+> **Second site, 100G switched fabric:** [docs/FIELD-NOTES-4NODE-100G.md](docs/FIELD-NOTES-4NODE-100G.md)
+> reproduces this recipe on four GX10 through an Arista 7060CX-32S at 100G. Decode matched
+> the 200G numbers, which suggests it is not fabric-bound. Also covers a GID-index lookup
+> for the launcher, why AOC transceivers overheat in the GX10 cages, and moving 185 GB
+> between nodes without encrypting it.
+
 ## The configuration
 
 **This is the current default. Everything else in this README is either an alternative lane

--- a/docs/FIELD-NOTES-4NODE-100G.md
+++ b/docs/FIELD-NOTES-4NODE-100G.md
@@ -1,0 +1,139 @@
+# Field notes: reproducing this on a 100G switched fabric
+
+Second site, different fabric. Four ASUS Ascent GX10 through an Arista 7060CX-32S at
+100G with passive DAC, rather than the direct-cabled 200G setup this recipe was written
+on. The recipe held. What follows is what we hit that is not already in the README, and
+one launcher change we think belongs upstream.
+
+## Decode is not fabric-bound on this model
+
+The most useful thing we can report is a negative result. At 100G, single rail, we get
+numbers that match the reference build on 200G:
+
+| Content regime | TTFT | Decode |
+|---|---|---|
+| structured | 0.254 s | 76.0 tok/s |
+| code | 0.187 s | 71.3 tok/s |
+| prose | 0.185 s | 31.6 tok/s |
+
+Concurrency 1 / 2 / 8: 65.4, 104.2, 99.9 tok/s aggregate. KV pool 3,895,606 tokens.
+DFlash2 accepts 5.43 of 7 draft tokens.
+
+Halving fabric bandwidth changed nothing measurable in decode, which means anyone
+planning a build should spend on nodes before spending on switching. Prefill of long
+contexts and heavy multi-tenant load are where more fabric would still pay.
+
+For reference, the same cluster before the RedHatAI checkpoint and DFlash2, running
+ModelOpt weights with MTP-4: 64.0 structured, 46.9 code, 33.4 prose. Changing the
+checkpoint and drafter moved code generation by half and left prose where it was.
+
+## `NCCL_IB_GID_INDEX` should be looked up, not pinned
+
+The RoCEv2/IPv4 GID does not sit at the same index on every node. On our four, rail A
+was 3, 3, 3, 4. An index becomes a hole when an address is removed and re-added, so the
+new GID lands in the next free slot instead of the old one.
+
+Getting it wrong fails in two different ways, and the second one is expensive:
+
+- a wrong explicit index gives `ibv_modify_qp failed ... local GID ::`, which is clear
+- leaving it unset so NCCL auto-selects makes the collective **hang**: twenty minutes of
+  no log output, GPUs at 96% utilisation
+
+That second signature is worth internalising. **96% utilisation at 22 W is not compute.**
+A GB10 loading weights draws far more. High utilisation with low power means a spin-wait
+on a collective that will never complete, and `nvidia-smi --query-gpu=utilization.gpu,power.draw`
+tells you in five seconds what the log will not tell you at all.
+
+Pinning per rank is not enough either. We rebooted the fleet a few times for unrelated
+reasons and one node's GID moved from 4 back to 3, so a pin that had been correct became
+a pin to an empty slot. That failure looks different again: `NCCL error: unhandled system
+error` at init, on one rank only, with the head reporting nothing more useful than
+"WorkerProc initialization failed". Relaunching does not help, because nothing about a
+relaunch changes the pin.
+
+The launcher in this fork reads the index from sysfs before starting the container and
+keeps the pinned value as a fallback. Six lines, and it prints what it chose:
+
+```
+using NCCL_IB_GID_INDEX=3
+```
+
+## Moving the weights and the image without wasting the fabric
+
+`docker save | ssh` and rsync over SSH both encrypt, and AES on the GB10's ARM cores
+tops out near 1 Gbps. On a 100G fabric that is one percent of the wire, and the rails are
+an isolated L2 segment with nothing to protect the traffic from.
+
+An rsync daemon, read-only and restricted to the rail subnets, moved a 4 GiB shard at
+1977 MB/s against roughly 1 Gbps over SSH:
+
+```ini
+# /etc/rsyncd.conf
+uid = mtxc
+gid = mtxc
+use chroot = no
+read only = yes
+hosts allow = 10.77.1.0/24 10.77.2.0/24
+hosts deny = *
+
+[models]
+path = /var/tmp
+```
+
+The image goes the same way: `docker save` to a tar under the module root, each node
+pulls it and runs `docker load`. Costs 31 GB of scratch and one extra write-read cycle,
+still far quicker than encrypting the same bytes. This matters more as model sizes grow;
+185 GB over SSH is most of an afternoon.
+
+## The watchdog needs turning off before maintenance
+
+`fleet_watchdog.sh` does exactly what it should, which is the problem. Halfway through
+swapping the image and the checkpoint it saw `/health` fail, concluded the fleet was
+down, tore down the containers we had just started by hand, and relaunched from its own
+configuration. That configuration still named the previous launcher, which a pull from
+here had deleted on the head node. Three workers came up on the old stack with no head at
+all, which is worse than either state we were moving between.
+
+Stop it first, start it after a verified launch. And after every pull, re-check the four
+things the watchdog holds its own copy of: the launcher path, the node map, the SSH key,
+and the health URL. A renamed launcher upstream is enough to break it silently.
+
+## Hardware: do not use AOC in the QSFP cages
+
+This cost us a day and is not a software problem.
+
+The GX10 draws air in through the bottom and exhausts out the back, which is where the
+QSFP cages are, so the transceivers sit in the node's own hot exhaust. With a 3.5 W AOC
+in both cages the modules idle at 68 to 72 C against a 70 C warning and 75 C alarm. Under
+load they cross it and the driver protects the optics:
+
+```
+mlx5_core: Port module event[error]: module 0, Cable error, High Temperature
+mlx5_core enp1s0f0np0: Link down
+```
+
+A worker's rail disappearing mid-inference kills the engine with
+`TimeoutError: RPC call to sample_tokens timed out`, which reads like a software fault and
+is not one.
+
+Nothing helps from software. Bringing the idle cage's interface down bought 1 C, because
+the module stays powered, and `ethtool --set-module power-mode-policy` is not supported on
+this device. Passive DAC dissipates 1.5 W, has no laser and no temperature sensor at all,
+and the failure mode disappears with it. After the swap: 98.01 Gbps per link, 2.58 us
+latency, no flaps.
+
+Placement matters too. Ours were stacked, and the two in the middle of the row ran 81 to
+84 C on the board against 70 to 73 at the edges. Bottom intake means each unit wants
+clearance underneath.
+
+## Measuring decode speed
+
+Our first benchmark reported a flat 13.7 tok/s across every content type while the
+engine's own metrics said 25 to 50. The benchmark counted SSE chunks, and with
+speculative decoding one chunk carries several tokens. Ask the server instead:
+
+```json
+{"stream": true, "stream_options": {"include_usage": true}}
+```
+
+then divide `completion_tokens` by the time from first token to last.

--- a/launch-glm53-tp4-24g.sh
+++ b/launch-glm53-tp4-24g.sh
@@ -29,6 +29,22 @@ case "$NODE_RANK" in
 esac
 
 # Fail loudly on missing prereqs rather than letting Docker create empty dirs over them.
+# The RoCEv2 GID index is not stable across link bounces and reboots, so look it up
+# instead of trusting NCCL_IB_GID_INDEX below. A stale index fails at init with
+# "unhandled system error" on one rank and nothing useful from the head; an unset one
+# makes the collective hang silently. See docs/FIELD-NOTES-4NODE-100G.md.
+GIDX=3
+DETECTED_GIDX=""
+for _i in 0 1 2 3 4 5 6 7; do
+  _t=$(cat /sys/class/infiniband/rocep1s0f0/ports/1/gid_attrs/types/$_i 2>/dev/null)
+  _g=$(cat /sys/class/infiniband/rocep1s0f0/ports/1/gids/$_i 2>/dev/null)
+  case "$_t" in *"RoCE v2"*)
+    case "$_g" in *ffff*) DETECTED_GIDX=$_i; break ;; esac ;;
+  esac
+done
+[ -n "$DETECTED_GIDX" ] && GIDX=$DETECTED_GIDX
+echo "using NCCL_IB_GID_INDEX=$GIDX"
+
 test -f "$MODEL_HOST_PATH/config.json"       || { echo "MISSING: $MODEL_HOST_PATH/config.json" >&2; exit 3; }
 test -f "$MODEL_HOST_PATH/chat_template_mm.jinja" || { echo "MISSING: chat_template_mm.jinja in the weights dir (vision will 500)" >&2; exit 3; }
 test -f "$HOME/patches/sparse_attn_indexer_kpool.py" || { echo "MISSING: \$HOME/patches/sparse_attn_indexer_kpool.py -- cp it from docker/sparse_attn_indexer_kpool_sm121.py. Without it the engine dies on every decode past ~24K context." >&2; exit 3; }
@@ -51,7 +67,7 @@ docker run --gpus all -d \
   -e TORCH_CUDA_ARCH_LIST=12.1a -e FLASHINFER_CUDA_ARCH_LIST=12.1a \
   -e FLASHINFER_DISABLE_VERSION_CHECK=1 \
   -e NCCL_NET=IB -e NCCL_IB_DISABLE=0 \
-  -e NCCL_IB_HCA=rocep1s0f0 -e NCCL_IB_GID_INDEX=3 \
+  -e NCCL_IB_HCA=rocep1s0f0 -e NCCL_IB_GID_INDEX=$GIDX \
   -e NCCL_IB_ROCE_VERSION_NUM=2 -e NCCL_IB_ADDR_FAMILY=AF_INET \
   -e NCCL_IB_ADDR_RANGE=192.168.192.0/24 \
   -e NCCL_SOCKET_IFNAME=enp1s0f0np0 -e GLOO_SOCKET_IFNAME=enp1s0f0np0 \


### PR DESCRIPTION
Reproduced this recipe at a second site and it held. Two things came out of it that seem
worth sending back: one launcher change, and a notes file for anyone on a switched
fabric.

**Setup:** four ASUS Ascent GX10 through an Arista 7060CX-32S at 100G with passive DAC,
rather than direct-cabled 200G. TP=4, RedHatAI checkpoint, DFlash2 k=7, everything else
as documented here.

### Look the GID index up instead of pinning it

`launch-glm53-tp4-24g.sh` now reads the RoCEv2/IPv4 GID index from sysfs before starting
the container, keeping the existing value as a fallback. Six lines, prints what it picked.

We needed this because the index is not the same on every node (ours were 3, 3, 3, 4 on
rail A) and it is not stable either. After a few unrelated reboots one node's GID moved
from 4 back to 3, so a pin that had been correct became a pin to an empty slot.

The two failure modes look nothing alike, which is what made it expensive:

- wrong explicit index: `ibv_modify_qp failed ... local GID ::`, clear enough
- stale pin: `NCCL error: unhandled system error` at init on one rank only, head says
  just "WorkerProc initialization failed", and relaunching cannot help since nothing
  about a relaunch changes the pin
- unset, letting NCCL auto-select: the collective **hangs** with no log output at all

For that last one, the tell is `nvidia-smi`. 96% GPU utilisation at 22 W is not compute,
it is a spin-wait on a collective that will never finish. A GB10 actually loading weights
draws far more. That check takes five seconds and the log never tells you.

### docs/FIELD-NOTES-4NODE-100G.md

Mostly a negative result that seems useful for people planning a build: **decode did not
appear to be fabric-bound**. At 100G single rail we measured 76.0 tok/s structured, 71.3
on code, 31.6 on prose, TTFT 0.19 to 0.25 s, KV pool 3,895,606 tokens, DFlash2 accepting
5.43 of 7. Those match the 200G numbers here. Halving fabric bandwidth changed nothing
measurable, so nodes look like the better place to spend than switching.

Also in there, briefly:

- **AOC transceivers cook themselves in the GX10 cages.** Bottom intake, rear exhaust, and
  the QSFP cages sit in the node's own exhaust. Two 3.5 W AOCs put the modules at 68 to
  72 C against a 70 C warning, and under load the driver drops the link with
  `Cable error, High Temperature`. A worker's rail vanishing mid-inference surfaces as
  `TimeoutError: RPC call to sample_tokens timed out`, which reads like a software bug.
  Nothing helps in software: admin-down bought 1 C, and `--set-module power-mode-policy`
  is unsupported here. Passive DAC is 1.5 W with no laser and the problem disappears.
- **Distributing weights over an rsync daemon instead of SSH.** AES on the GB10's ARM
  cores caps a stream near 1 Gbps. Read-only daemon restricted to the rail subnets moved
  a 4 GiB shard at 1977 MB/s. Same trick for the image via `docker save`.
- **Stop `fleet_watchdog.sh` before maintenance.** It did exactly its job during an image
  and checkpoint swap: saw `/health` fail, tore down containers we had started by hand,
  and relaunched from its own config, which still named a launcher a pull from here had
  deleted. Three workers on the old stack, no head.
- How not to measure decode speed: counting SSE chunks under-reports by roughly 3x with
  speculative decoding, since one chunk carries several tokens.

Happy to split this into two PRs, or drop the notes file and keep only the launcher
change, if you would rather keep the docs tree yours. Thanks for the recipe.


