### PR TITLE
Cleanup step 1: CURRENT.md, RedHatAI default + ModelOpt guard in the launcher, Dockerfile chain sync

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!-- This repo keeps ONE current recipe, written down in CURRENT.md. A PR is checked against that file, not against the whole tree. -->
+
+**Which line of CURRENT.md does this change?**
+(quote it, or write "none: docs/tooling only")
+
+**What is the new value, and what number proves it?**
+(flag, before -> after, the prompt type and temperature of the measurement, and where the log or JSON lives)
+
+**Tested on**
+(hardware, image tag, weights dir, date)
+
+**Checklist**
+- [ ] I rebased on current `main` (stale PRs merge old configs over the current recipe)
+- [ ] `CURRENT.md` updated in this PR if a launcher or a serving flag changed, and `bash tools/check-current.sh --write` was run
+- [ ] Speed numbers are from real prompts (prose, code, ...); any counting-prompt number is labeled as the draft-acceptance ceiling; prefill is cold

--- a/.github/workflows/current-check.yml
+++ b/.github/workflows/current-check.yml
@@ -1,0 +1,25 @@
+name: CURRENT.md guard
+# Fails a PR that changes a launcher without changing CURRENT.md, or whose CURRENT.md
+# launcher hashes do not match the launchers in the tree. Keeps the golden recipe honest:
+# any config change has to be written down in the one file agents read first.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with: {fetch-depth: 0}
+      - name: launchers changed => CURRENT.md must change too (PRs only)
+        if: github.event_name == 'pull_request'
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          changed=$(git diff --name-only "$base" HEAD)
+          if echo "$changed" | grep -qE '^(launchers/|launch-[^/]*\.sh$|[^/]*launch[^/]*\.sh$)'; then
+            echo "$changed" | grep -q '^CURRENT.md$' || { echo "::error::a launcher changed but CURRENT.md did not. Update the golden record in the same PR."; exit 1; }
+          fi
+      - name: CURRENT.md hashes match the launchers
+        run: bash tools/check-current.sh

--- a/CURRENT.md
+++ b/CURRENT.md
@@ -59,3 +59,7 @@ Decode is quoted from real prompts (prose, code, and the other categories above)
 `launch-glm53-tp4-dflash2-topkfix.sh` and `docker/topkfix/` (eager-only alternate lane, gmu 0.72, seqs 16), `docker/Dockerfile.glm53-sm121-v2` and `-v9` as build targets (v8 is the published base), `overlay-dflash2/` (duplicate of `docker/dflash2-overlay/`), `docs/DEPLOY-REPORT.md` (a TP2 report), `docs/GB10-KV-MEMORY-LADDER.md`, `docs/BENCH-C1-C6-DFLASH2.md`, `docs/NVFP4-KV-BUILD-SPEC.md`, `probes/bench_c1c6.py`, `probes/bench_glm53.py`.
 
 Two Sparks only: the sibling repo `GLM-5.3-Flash-NVFP4-DFlash2-2x-DGX-Spark` (TP2, 262K, enforce-eager, KV pinned 6 GiB).
+
+<!-- launcher hashes, maintained by tools/check-current.sh --write -->
+sha256 585f59d5882ac9b955f25a8d02a2626b90a6663277673ac195926a803bca6bc9  launch-glm53-tp4-24g.sh
+sha256 5e1ce6b9c9afe00bbcac10445573753c557876bea3ab7205fbbac3c0d3f9b605  launch-glm53-tp4-dflash2-topkfix.sh

--- a/CURRENT.md
+++ b/CURRENT.md
@@ -1,0 +1,61 @@
+# CURRENT recipe (read this first)
+
+**GLM-5.3-Flash NVFP4, tensor-parallel 4 across four DGX Spark, 1M context, DFlash2 drafter, CUDA graphs.**
+Updated 2026-09-02. If a file in this repo disagrees with this page, this page wins and the file is history.
+
+## The one launcher
+
+`launch-glm53-tp4-24g.sh <rank>` on every node, **workers first: rank 3, then 2, then 1, then rank 0 (the head)**.
+
+| rank | node | ring IP | role |
+|---|---|---|---|
+| 0 | Reddie | 192.168.192.2 | head, serves `:8000`, model id `glm-5.3-flash` |
+| 1 | Spark4 | 192.168.192.4 | worker |
+| 2 | Asusi | 192.168.192.3 | worker |
+| 3 | Bluey | 192.168.192.1 | worker |
+
+Before launching on every node: `flusher-unconditional.sh` running, `sync; echo 3 | sudo tee /proc/sys/vm/drop_caches`, and after any reboot check `nvidia-smi --query-gpu=clocks.sm --format=csv` under load (a post-reboot node can sit at ~611 MHz and halve every number).
+
+## What it runs
+
+| | value |
+|---|---|
+| image | `ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v11-dflash2` |
+| weights | `/var/tmp/models/GLM-5.3-Flash-NVFP4-redhat` = **RedHatAI/GLM-5.3-Flash-NVFP4 (compressed-tensors)**. ModelOpt and abliterated NVFP4 builds corrupt token IDs (vLLM #54150); the launcher refuses them unless `ALLOW_MODELOPT=1`. |
+| drafter | `incoai/GLM-5.3-Flash-DFlash2`, `num_speculative_tokens: 7` |
+| context | `--max-model-len 1048576` |
+| KV | `--kv-cache-dtype fp8_e4m3 --kv-cache-memory 25769803776` (24 GiB per rank), `--block-size 2304` |
+| concurrency | `--max-num-seqs 64 --max-num-batched-tokens 16384` |
+| graphs | `--compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE"}'` (NOT `--enforce-eager`; eager belongs only to the b12x/NVFP4-KV lane and the topkfix image) |
+| MoE | `--moe-backend marlin`, `--gpu-memory-utilization 0.85` |
+| vision | on, `chat_template_mm.jinja` mounted from the weights dir |
+| watchdog | `fleet_watchdog.sh` (hard-codes the launcher name; do not rename the launcher) |
+
+## What to expect (measured 2026-09-02, this exact config, isolated, temperature 0)
+
+| | |
+|---|---|
+| boot | healthy in ~16 min (13 min load + 96 s graph capture, 6.45 GiB of graphs) |
+| KV pool | `GPU KV cache size: 3,834,498 tokens` |
+| real prompts, single stream | prose **31** tok/s, narrative 32, code **75**, reasoning 73, JSON 80, HTML 94, summary 60 (40-prompt battery, median) |
+| real prompts, mixed load | 4 streams 74 tok/s aggregate (first token 0.94 s); 16 streams 100 tok/s (first token 2.2 s) |
+| fresh 1.6K prompt, first token | 0.91 s single stream |
+| cold prefill | 2.0K tok/s at 7K tokens, 3.0K at 28K, 3.8K at 110K, 4.8K at 182K (fresh prompt, no cache) |
+| power at 16 streams | 156 W across four GPUs, 2.99 tokens per joule |
+| ceiling (counting prompt, max draft acceptance, not a decode number) | 100 tok/s single stream, 817 tok/s aggregate at 48 streams |
+
+Side by side with DeepSeek V4 Flash Vision at the same TP4 config, same day: https://github.com/tonyd2wild/GLM-5.3-Flash-EXL3-on-2x-NVIDIA-DGX-Spark/blob/main/results/h2h_tp4.md
+
+## How we quote numbers
+
+Decode is quoted from real prompts (prose, code, and the other categories above). The counting prompt is reported only as the drafter's acceptance ceiling and labeled as such. Prefill is quoted cold, from a fresh prompt at a fixed length, never from a cached context. Every number carries the prompt type and the temperature.
+
+## Sweep harness
+
+`tools/exp-glm53-tp4.sh` is the same recipe with every knob exposed as an env var (`EAGER`, `CUDAGRAPH_MODE`, `MAX_NUM_SEQS`, `MAX_BATCHED`, `SPEC_JSON`, `EXP_NAME`). Defaults equal the recipe above. Use it for one-knob experiments; serve with the launcher.
+
+## Do not use (history, moving to `archive/` in the next commit)
+
+`launch-glm53-tp4-dflash2-topkfix.sh` and `docker/topkfix/` (eager-only alternate lane, gmu 0.72, seqs 16), `docker/Dockerfile.glm53-sm121-v2` and `-v9` as build targets (v8 is the published base), `overlay-dflash2/` (duplicate of `docker/dflash2-overlay/`), `docs/DEPLOY-REPORT.md` (a TP2 report), `docs/GB10-KV-MEMORY-LADDER.md`, `docs/BENCH-C1-C6-DFLASH2.md`, `docs/NVFP4-KV-BUILD-SPEC.md`, `probes/bench_c1c6.py`, `probes/bench_glm53.py`.
+
+Two Sparks only: the sibling repo `GLM-5.3-Flash-NVFP4-DFlash2-2x-DGX-Spark` (TP2, 262K, enforce-eager, KV pinned 6 GiB).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# GLM-5.3-Flash · DFlash2 · TP4 · 1M Context · 3.9M-Token KV
+# GLM-5.3-Flash · DFlash2 · TP4 · 1M Context · 3.8M-Token KV
+
+> **Current recipe, one page: [CURRENT.md](CURRENT.md).** One launcher (`launch-glm53-tp4-24g.sh`), RedHatAI weights only, CUDA graphs on. Everything below is reference or history.
 
 > 🔀 **Only have two Sparks?** The same images run at TP2 (262K context) — see the sibling repo:
 > **[GLM-5.3-Flash NVFP4 + DFlash2 · 2x DGX Spark →](https://github.com/tonyd2wild/GLM-5.3-Flash-NVFP4-DFlash2-2x-DGX-Spark)**
@@ -49,6 +51,11 @@ or history — both are labelled as such.**
 | **Aggregate throughput** | **530.0 tok/s** @C48 (was 183.1 @C6 before the three changes below) |
 | Single stream | **105.6** count-to-100 · **77.3** code · **31.5** prose (temperature 0, median of 3) |
 | Prefill | **1,863 tok/s** warmed @114K prompt · TTFT **54.8 s** (was 1,194 / 95.4 s) |
+| **Weights** | **RedHatAI/GLM-5.3-Flash-NVFP4 (compressed-tensors) only.** ModelOpt / abliterated builds corrupt token IDs; the launcher refuses them (`ALLOW_MODELOPT=1` to override) |
+| Vision | on (`chat_template_mm.jinja`) |
+| Thinking | off by default |
+| Launcher | [`launch-glm53-tp4-24g.sh`](launch-glm53-tp4-24g.sh) (do not rename: `fleet_watchdog.sh` hard-codes it) |
+| Flusher | [`flusher-unconditional.sh`](flusher-unconditional.sh) — **required, and must be unconditional** |
 
 ### What changed, and what each part bought (measured 2026-08-31 → 09-02)
 
@@ -70,11 +77,6 @@ or history — both are labelled as such.**
 > is content-driven, so the same engine measures 105.6 on count-to-100 and 31.5 on dense
 > prose, minutes apart. The harness ([`probes/bench_glm53_tp4.py`](probes/bench_glm53_tp4.py))
 > uses a fixed 8-prompt set at temperature 0 with median-of-N for exactly this reason.
-| Weights | abliterated or stock NVFP4, drop-in either way |
-| Vision | on (`chat_template_mm.jinja`) |
-| Thinking | off by default |
-| Launcher | [`launch-glm53-tp4-24g.sh`](launch-glm53-tp4-24g.sh) |
-| Flusher | [`flusher-unconditional.sh`](flusher-unconditional.sh) — **required, and must be unconditional** |
 
 Gate-passed 2026-08-29: two deep decodes at ~41K context (392 and 399 decoded tokens),
 3x concurrent prefills at 32,879 tokens each, vision, `/health` 200 throughout. Residual
@@ -190,7 +192,7 @@ calling ships enabled (`glm47` parser).
 ### Verify the boot
 
 ```
-GPU KV cache size: 3,895,606 tokens, Maximum concurrency for 1,048,576 tokens per request: 3.72x
+GPU KV cache size: 3,895,606 tokens, Maximum concurrency for 1,048,576 tokens per request: 3.72x   # eager run; with CUDA graphs on, 3,834,498 (graph buffers take 0.86 GiB)
 ```
 
 **Your number will differ**, and that is expected — see *Measure your own ceiling* above.
@@ -230,7 +232,7 @@ figure is really a statement about the prompt. **Quote the prompt or the number 
 meaningless.** Cumulative acceptance across our gate suite was 0.271, but that suite was
 deliberately prose-heavy and understates normal traffic.
 
-`--max-num-batched-tokens 8192` is set. Left unset, vLLM derives 2048 from the speculative
+`--max-num-batched-tokens 16384` is set (8192 until 2026-09-01; see the change table at the top). Left unset, vLLM derives 2048 from the speculative
 settings and warns that this is suboptimal. The ladder on a 32K prompt — 2048 -> 4096 ->
 8192 for -29 % TTFT and +42 % prefill at about +1 GiB — is
 [tonyliu312's measurement](https://github.com/tonyliu312/GLM-5.3-Flash-DFlash2-TP4-1M-Context);

--- a/docker/Dockerfile.glm53-sm121-v2
+++ b/docker/Dockerfile.glm53-sm121-v2
@@ -1,4 +1,5 @@
-FROM radixark/vllm-glm53-flash:sm121-nope-mla
+#FROM radixark/vllm-glm53-flash:sm121-nope-mla
+FROM radixark/vllm-glm53-flash:sm121-v1
 
 # Debug build: env-gated NaN localizer. With GLM53_NAN_DEBUG=1, installs a
 # forward hook on every submodule of Glm5NextModel that logs the first module

--- a/docker/Dockerfile.glm53-sm121-v3
+++ b/docker/Dockerfile.glm53-sm121-v3
@@ -1,4 +1,5 @@
-FROM radixark/vllm-glm53-flash:sm121-nope-mla
+#FROM radixark/vllm-glm53-flash:sm121-nope-mla
+FROM radixark/vllm-glm53-flash:sm121-v1
 
 # FlashInfer 0.6.17's FA2 MLA kernel produces NaN for 64-256-row batches on
 # SM121 (probed and bisected on Reddie's GPU; 1-6 and 512+ rows are clean).

--- a/docker/Dockerfile.glm53-sm121-v4
+++ b/docker/Dockerfile.glm53-sm121-v4
@@ -1,4 +1,5 @@
-FROM radixark/vllm-glm53-flash:sm121-fi618
+#FROM radixark/vllm-glm53-flash:sm121-fi618
+FROM radixark/vllm-glm53-flash:sm121-v3
 
 # flashinfer 0.6.18 nightly silently downgraded nvidia-nccl-cu13 2.30.7 -> 2.29.7,
 # which fails ncclCommInitRank with internal error on the Spark IB fabric.

--- a/docker/Dockerfile.glm53-sm121-v5
+++ b/docker/Dockerfile.glm53-sm121-v5
@@ -1,4 +1,5 @@
-FROM radixark/vllm-glm53-flash:sm121-fi618-nccl
+#FROM radixark/vllm-glm53-flash:sm121-fi618-nccl
+FROM radixark/vllm-glm53-flash:sm121-v4
 
 # The flashinfer 0.6.18 nightly also bumped nvidia-cutlass-dsl to a mixed 4.7.0/4.6.2
 # state, ICEing the CuTeDSL warmup (cute-to-nvvm). Restore the 4.6.2 family the image

--- a/docker/Dockerfile.glm53-sm121-v6
+++ b/docker/Dockerfile.glm53-sm121-v6
@@ -1,4 +1,5 @@
-FROM radixark/vllm-glm53-flash:sm121-final
+#FROM radixark/vllm-glm53-flash:sm121-final
+FROM radixark/vllm-glm53-flash:sm121-v5
 
 # PDL (Programmatic Dependent Launch) is enabled for any capability >= 9,
 # including SM121, in the Triton kernels that carry KDA recurrent state

--- a/launch-glm53-tp4-24g.sh
+++ b/launch-glm53-tp4-24g.sh
@@ -13,7 +13,21 @@ NODE_RANK="${1:?usage: launch-glm53-tp4-24g.sh <0|1|2|3>}"
 
 IMAGE="ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v11-dflash2"
 NAME="vllm_glm53"
-MODEL_HOST_PATH="/var/tmp/models/keys-glm-5.3-flash-nvfp4-ablit-l15-45-anchorstock"
+# Checkpoint. The documented default is RedHatAI/GLM-5.3-Flash-NVFP4 (compressed-tensors)
+# because the ModelOpt builds emit intermittent corrupted token IDs (vLLM #54150, README
+# table above). This launcher previously hard-coded the abliterated ModelOpt path, so the
+# shipped default did not match the documented one. Override with MODEL_HOST_PATH=... only
+# for the legacy/abliterated builds, and set ALLOW_MODELOPT=1 to get past the guard below.
+MODEL_HOST_PATH="${MODEL_HOST_PATH:-/var/tmp/models/GLM-5.3-Flash-NVFP4-redhat}"
+if [ -f "$MODEL_HOST_PATH/config.json" ] && [ "${ALLOW_MODELOPT:-0}" != "1" ]; then
+  _q=$(python3 -c "import json;print(json.load(open('$MODEL_HOST_PATH/config.json')).get('quantization_config',{}).get('quant_method',''))" 2>/dev/null || echo "")
+  if [ "$_q" = "modelopt" ]; then
+    echo "REFUSING: $MODEL_HOST_PATH is a ModelOpt build (quant_method=modelopt)." >&2
+    echo "  ModelOpt NVFP4 emits intermittent corrupted token IDs (vLLM #54150)." >&2
+    echo "  Use RedHatAI/GLM-5.3-Flash-NVFP4, or set ALLOW_MODELOPT=1 to override." >&2
+    exit 5
+  fi
+fi
 MODEL_PATH="/models/glm-5.3-flash-nvfp4"
 CACHE_HOST_PATH="/var/tmp/glm53-vllm-cache"
 HEAD_IP="192.168.192.2"
@@ -116,7 +130,7 @@ docker run --gpus all -d \
     --master-addr "$HEAD_IP" --master-port "$MPORT" \
     $HEADLESS
 
-echo "launched $NAME rank=$NODE_RANK host=$HOST_IP tp4 kv=24GiB mnbt=8192"
+echo "launched $NAME rank=$NODE_RANK host=$HOST_IP tp4 kv=24GiB mnbt=16384 seqs=64 graphs=FULL_AND_PIECEWISE"
 sleep 2
 docker ps --format '{{.Names}} {{.Status}}' | grep "$NAME" || {
   echo "$NAME exited; inspect with: docker logs $NAME" >&2; exit 1; }

--- a/tools/check-current.sh
+++ b/tools/check-current.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# tools/check-current.sh: verify that every "sha256 <hex>  <path>" line in CURRENT.md matches the
+# file in the tree, and that every launcher listed under launchers/ (or the repo's named launcher)
+# has such a line. Run locally before a PR; CI runs it on every PR and push to main.
+#   Update the hashes after an intentional change:  bash tools/check-current.sh --write
+set -u
+cd "$(dirname "$0")/.."
+[ -f CURRENT.md ] || { echo "no CURRENT.md at the repo root"; exit 1; }
+sha() { if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | cut -c1-64; else shasum -a 256 "$1" | cut -c1-64; fi; }
+launchers=$( { ls launchers/*.sh 2>/dev/null; ls launch-*.sh 2>/dev/null; } | sort -u)
+if [ "${1:-}" = "--write" ]; then
+  tmp=$(mktemp)
+  grep -vE '^sha256 [0-9a-f]{64}  ' CURRENT.md > "$tmp"
+  { cat "$tmp"; echo; echo "<!-- launcher hashes, maintained by tools/check-current.sh --write -->"; for f in $launchers; do echo "sha256 $(sha "$f")  $f"; done; } > CURRENT.md
+  rm -f "$tmp"; echo "CURRENT.md hashes written for: $launchers"; exit 0
+fi
+rc=0
+for f in $launchers; do
+  want=$(grep -E "^sha256 [0-9a-f]{64}  $f\$" CURRENT.md | awk '{print $2}' | head -1)
+  have=$(sha "$f")
+  if [ -z "$want" ]; then echo "MISSING: $f has no sha256 line in CURRENT.md"; rc=1
+  elif [ "$want" != "$have" ]; then echo "DRIFT: $f changed but CURRENT.md still lists $want"; rc=1
+  else echo "ok: $f"; fi
+done
+[ $rc -eq 0 ] && echo "CURRENT.md matches the launchers." || echo "Fix: edit CURRENT.md to describe the change, then: bash tools/check-current.sh --write"
+exit $rc

--- a/tools/exp-glm53-tp4.sh
+++ b/tools/exp-glm53-tp4.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# tools/exp-glm53-tp4.sh: the SWEEP HARNESS for this recipe, not the serving launcher.
+# Same image, weights, ranks, KV pin, block size and drafter as launch-glm53-tp4-24g.sh, with
+# every tunable exposed as an env var so an experiment can flip one knob at a time (EAGER,
+# CUDAGRAPH_MODE, MAX_NUM_SEQS, MAX_BATCHED, SPEC_JSON, EXP_NAME picks a separate compile cache).
+# Defaults equal the current recipe, so a bare run reproduces launch-glm53-tp4-24g.sh.
+# Site-specific: workers read weights over NFS from the head at /mnt/reddie-models; edit for yours.
+# For serving, use launch-glm53-tp4-24g.sh (fleet_watchdog.sh hard-codes that name).
+# exp-glm53-tp4.sh <rank>  — experiment launcher for GLM-5.3-Flash TP4.
+#
+# Byte-identical to ~/revert-glm53-redhat-tp4.sh (the known-good recipe) EXCEPT that
+# the levers under test are read from the environment. Unset => baseline behaviour,
+# so an unparameterised run reproduces the known-good config exactly.
+#
+# Levers (export before running, same values on ALL FOUR nodes):
+#   EXP_NAME        label, also picks the per-experiment compile cache dir.
+#                   REQUIRED for k sweeps: vLLM's SpeculativeConfig.compute_hash()
+#                   omits num_speculative_tokens (vllm#53366), so sweeping k in one
+#                   cache dir silently reuses the wrong Inductor artifact.
+#   SPEC_JSON       full --speculative-config JSON. default: baseline dflash k=7
+#   EAGER           1 => --enforce-eager (baseline). 0 => use CUDAGRAPH_MODE
+#   CUDAGRAPH_MODE  PIECEWISE | FULL_DECODE_ONLY | FULL_AND_PIECEWISE | FULL
+#                   NOTE: 34 KDA layers are UNIFORM_SINGLE_TOKEN_DECODE, so FULL is
+#                   auto-downgraded and cannot graph a 1+K verify batch. PIECEWISE
+#                   is the mode to try first.
+#   MAX_NUM_SEQS    default 64 (the current recipe)
+#   MAX_BATCHED     default 16384 (the current recipe)
+#   NCCL_EXTRA      extra "-e K=V" docker env pairs, e.g. "-e NCCL_ALGO=Tree -e NCCL_PROTO=LL"
+#   VLLM_EXTRA      extra vllm serve args
+set -euo pipefail
+NODE_RANK="${1:?usage: exp-glm53-tp4.sh <0|1|2|3>}"
+
+EXP_NAME="${EXP_NAME:-baseline}"
+EAGER="${EAGER:-0}"
+CUDAGRAPH_MODE="${CUDAGRAPH_MODE:-FULL_AND_PIECEWISE}"
+MAX_NUM_SEQS="${MAX_NUM_SEQS:-64}"
+MAX_BATCHED="${MAX_BATCHED:-16384}"
+NCCL_EXTRA="${NCCL_EXTRA:-}"
+VLLM_EXTRA="${VLLM_EXTRA:-}"
+# NOTE: do NOT write this as "${SPEC_JSON:-{...}}". Bash matches the first unescaped `}`
+# as the end of the parameter expansion, so the trailing brace leaks out as a literal and
+# is appended to whatever the caller passed -- producing `...true}}` and a hard argparse
+# failure on every rank. Plain conditional assignment instead.
+if [ -z "${SPEC_JSON:-}" ]; then
+  SPEC_JSON='{"method":"dflash","model":"/models/dflash2-draft","num_speculative_tokens":7}'
+fi
+
+IMAGE="${IMAGE:-ghcr.io/tonyd2wild/vllm-glm53-flash:sm121-v11-dflash2}"
+NAME="vllm_glm53"
+MODEL_DIR="GLM-5.3-Flash-NVFP4-redhat"
+CACHE_HOST_PATH="/var/tmp/glm53-vllm-cache"
+HEAD_IP="192.168.192.2"; MPORT="29521"; PORT="8000"
+
+case "$NODE_RANK" in
+  0) HOST_IP=192.168.192.2; HEADLESS="";           MODEL_HOST="/var/tmp/models/$MODEL_DIR" ;;
+  1) HOST_IP=192.168.192.4; HEADLESS="--headless"; MODEL_HOST="/mnt/reddie-models/$MODEL_DIR" ;;
+  2) HOST_IP=192.168.192.3; HEADLESS="--headless"; MODEL_HOST="/mnt/reddie-models/$MODEL_DIR" ;;
+  3) HOST_IP=192.168.192.1; HEADLESS="--headless"; MODEL_HOST="/mnt/reddie-models/$MODEL_DIR" ;;
+  *) echo "rank must be 0-3" >&2; exit 2 ;;
+esac
+
+test -f "$MODEL_HOST/config.json" || { echo "MODEL MISSING at $MODEL_HOST" >&2; exit 3; }
+mkdir -p "$CACHE_HOST_PATH"
+docker rm -f "$NAME" 2>/dev/null || true
+
+# graph mode vs eager
+if [ "$EAGER" = "1" ]; then
+  GRAPH_ARGS="--enforce-eager"
+else
+  GRAPH_ARGS="--compilation-config {\"cudagraph_mode\":\"$CUDAGRAPH_MODE\"}"
+fi
+
+# shellcheck disable=SC2086
+# SKIP_INDEXER_MOUNT=1 for images with the PR#3 topk fix baked in: mounting the
+# SM-count-gated file over a baked fix silently reverts the thing under test.
+if [ "${SKIP_INDEXER_MOUNT:-0}" = "1" ]; then
+  INDEXER_MOUNT=""
+else
+  INDEXER_MOUNT="-v $HOME/patches/sparse_attn_indexer_kpool.py:/usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/sparse_attn_indexer_kpool.py:ro"
+fi
+
+docker run --gpus all -d --name "$NAME" --restart no \
+  --network host --ipc host --shm-size 32g --memory 112g --memory-swap 112g \
+  --ulimit memlock=-1:-1 --cap-add IPC_LOCK --device /dev/infiniband:/dev/infiniband \
+  -v "$MODEL_HOST:/models/glm-5.3-flash-nvfp4:ro" \
+  -v "$CACHE_HOST_PATH:/cache" \
+  -v /var/tmp/models/GLM-5.3-Flash-DFlash2:/models/dflash2-draft:ro \
+  ${INDEXER_MOUNT} \
+  -e VLLM_HOST_IP=$HOST_IP -e HF_HOME=/cache/huggingface -e HF_HUB_OFFLINE=1 -e TRANSFORMERS_OFFLINE=1 \
+  -e VLLM_CACHE_ROOT="/cache/vllm-$EXP_NAME" \
+  -e VLLM_ENGINE_READY_TIMEOUT_S=3600 -e PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+  -e TORCH_CUDA_ARCH_LIST=12.1a -e FLASHINFER_CUDA_ARCH_LIST=12.1a -e FLASHINFER_DISABLE_VERSION_CHECK=1 \
+  -e NCCL_NET=IB -e NCCL_IB_DISABLE=0 -e NCCL_IB_HCA=rocep1s0f0 -e NCCL_IB_GID_INDEX=3 \
+  -e NCCL_IB_ROCE_VERSION_NUM=2 -e NCCL_IB_ADDR_FAMILY=AF_INET -e NCCL_IB_ADDR_RANGE=192.168.192.0/24 \
+  -e NCCL_SOCKET_IFNAME=enp1s0f0np0 -e GLOO_SOCKET_IFNAME=enp1s0f0np0 -e TP_SOCKET_IFNAME=enp1s0f0np0 -e MN_IF_NAME=enp1s0f0np0 \
+  -e NCCL_NVLS_ENABLE=0 -e NCCL_CROSS_NIC=0 -e NCCL_IB_MERGE_NICS=0 -e NCCL_CUMEM_ENABLE=0 \
+  -e NCCL_IGNORE_CPU_AFFINITY=1 -e NCCL_DEBUG=WARN -e TORCH_NCCL_ASYNC_ERROR_HANDLING=1 \
+  $NCCL_EXTRA \
+  "$IMAGE" \
+    /models/glm-5.3-flash-nvfp4 \
+    --served-model-name glm-5.3-flash --host 0.0.0.0 --port "$PORT" --trust-remote-code \
+    --tensor-parallel-size 4 --gpu-memory-utilization 0.85 --max-model-len 1048576 \
+    --max-num-seqs "$MAX_NUM_SEQS" --block-size 2304 --moe-backend marlin \
+    --speculative-config "$SPEC_JSON" \
+    --kv-cache-dtype fp8_e4m3 --kv-cache-memory 25769803776 \
+    $GRAPH_ARGS \
+    --max-num-batched-tokens "$MAX_BATCHED" --tool-call-parser glm47 --enable-auto-tool-choice \
+    --reasoning-parser glm45 --chat-template /models/glm-5.3-flash-nvfp4/chat_template_mm.jinja \
+    --default-chat-template-kwargs '{"enable_thinking": false}' \
+    --distributed-executor-backend mp --nnodes 4 --node-rank "$NODE_RANK" \
+    --master-addr "$HEAD_IP" --master-port "$MPORT" $HEADLESS $VLLM_EXTRA
+
+echo "launched $NAME rank=$NODE_RANK exp=$EXP_NAME eager=$EAGER graph=$CUDAGRAPH_MODE seqs=$MAX_NUM_SEQS"
+sleep 2
+docker ps --format '{{.Names}} {{.Status}}' | grep "$NAME" || { echo "$NAME exited" >&2; exit 1; }


### PR DESCRIPTION
Step 1 of the repo cleanup (nothing archived or deleted yet; that is the next PR). Goal: an agent that opens this repo lands on one page that says exactly what runs.

- `CURRENT.md`: the one launcher, rank order, image, weights, every flag, expected numbers measured 2026-09-02 on this exact config, and the reporting convention (decode from real prompts; counting prompt only as a labeled ceiling; prefill cold only).
- `launch-glm53-tp4-24g.sh`: **correctness fix.** It hard-coded the abliterated ModelOpt checkpoint (`keys-glm-5.3-flash-nvfp4-ablit-l15-45-anchorstock`) that this README documents as corrupting token IDs. Now defaults to `/var/tmp/models/GLM-5.3-Flash-NVFP4-redhat`, overridable with `MODEL_HOST_PATH`, with the same ModelOpt refusal guard the TP2 repo ships (`ALLOW_MODELOPT=1` to bypass). The success echo said `mnbt=8192`; the flag is 16384.
- `docker/Dockerfile.glm53-sm121-v2..v6`: synced from the TP2 repo, whose PR #5 fixed the `FROM` chain; this copy still pointed at tags that no longer exist.
- `tools/exp-glm53-tp4.sh`: the env-parameterized sweep harness the 08-31 and 09-02 runs actually used, defaults set to this recipe, labeled as a harness (the launcher stays the one serving script; `fleet_watchdog.sh` hard-codes its name).
- README: pointer to CURRENT.md at the top; the config table had five orphan rows after a blockquote that did not render; the weights row said "abliterated or stock, drop-in either way" against the checkpoint section above it; the `--max-num-batched-tokens 8192` sentence contradicted the table.

Head-to-head with DeepSeek V4 Flash Vision at the same TP4 config: https://github.com/tonyd2wild/GLM-5.3-Flash-EXL3-on-2x-NVIDIA-DGX-Spark/blob/main/results/h2h_tp4.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142pDPCMasdrPVASkqdsC5Y